### PR TITLE
fix: semicircle chart size

### DIFF
--- a/packages/ez-dev/jest/snapshots/recipes/pie/SemiCircleChart.spec.tsx.snap
+++ b/packages/ez-dev/jest/snapshots/recipes/pie/SemiCircleChart.spec.tsx.snap
@@ -18,7 +18,7 @@ exports[`SemiCircleChart renders a semi-circle chart 1`] = `
               class="ez-pie"
             >
               <path
-                d="M-96.56781074217112,-297.2051613422355L0,0Z"
+                d="M-123.60679774997902,-380.4226065180614L0,0Z"
                 fill="red"
                 stroke="#FFF"
                 stroke-width="0"
@@ -27,7 +27,7 @@ exports[`SemiCircleChart renders a semi-circle chart 1`] = `
               >
               </path>
               <path
-                d="M312.5,0L0,0Z"
+                d="M400,0L0,0Z"
                 fill="green"
                 stroke="#FFF"
                 stroke-width="0"
@@ -108,7 +108,7 @@ exports[`SemiCircleChart renders a semi-circle chart 2`] = `
               class="ez-pie"
             >
               <path
-                d="M-96.56781074217112,-297.2051613422355A312.5,312.5,0,0,0,-312.5,-3.827021247335479e-14L0,0Z"
+                d="M-123.60679774997902,-380.4226065180614A400,400,0,0,0,-400,-4.898587196589413e-14L0,0Z"
                 fill="red"
                 stroke="#FFF"
                 stroke-width="0"
@@ -117,7 +117,7 @@ exports[`SemiCircleChart renders a semi-circle chart 2`] = `
               >
               </path>
               <path
-                d="M312.5,0A312.5,312.5,0,0,0,-96.56781074217112,-297.2051613422355L0,0Z"
+                d="M400,0A400,400,0,0,0,-123.60679774997902,-380.4226065180614L0,0Z"
                 fill="green"
                 stroke="#FFF"
                 stroke-width="0"

--- a/packages/ez-react/src/recipes/pie/SemiCircleChart.tsx
+++ b/packages/ez-react/src/recipes/pie/SemiCircleChart.tsx
@@ -61,9 +61,7 @@ export const SemiCircleChart: FC<SemiCircleChartProps> = ({
       <Pie
         aScale={scale}
         getCenter={({ width, height }) => ({ x: width / 2, y: height })}
-        getRadius={({ width, height }) =>
-          height / 2 + width ** 2 / (8 * height)
-        }
+        getRadius={({ width, height }) => Math.min(width, height)}
         startAngle={Math.PI / 2}
         endAngle={-Math.PI / 2}
         {...arc}

--- a/packages/ez-vue/src/recipes/pie/SemiCircleChart.tsx
+++ b/packages/ez-vue/src/recipes/pie/SemiCircleChart.tsx
@@ -94,14 +94,10 @@ export default class SemiCircleChart extends Vue {
   private readonly arc!: PieConfig;
 
   @Prop({
-    type: Function as PropType<
-      (dimensions: Dimensions) => void
-    >,
+    type: Function as PropType<(dimensions: Dimensions) => void>,
     required: false,
   })
-  private readonly onResize?: (
-    dimensions: Dimensions,
-  ) => void;
+  private readonly onResize?: (dimensions: Dimensions) => void;
 
   private scale!: ScaleLinear;
 
@@ -142,10 +138,11 @@ export default class SemiCircleChart extends Vue {
         onResize={onResize}
       >
         <Pie
-          getCenter={({ width, height }: Dimensions) => ({ x: width / 2, y: height })}
-          getRadius={({ width, height }: Dimensions) => (
-            height / 2 + width ** 2 / (8 * height)
-          )}
+          getCenter={({ width, height }: Dimensions) => ({
+            x: width / 2,
+            y: height,
+          })}
+          getRadius={({ width, height }: Dimensions) => Math.min(width, height)}
           startAngle={Math.PI / 2}
           endAngle={-Math.PI / 2}
           aScale={scale}


### PR DESCRIPTION
# Motivation

The semicircle chart is getting a radius bigger than its container. I changed the callback function `getRadius` that is passed as a prop in the semicircle chart.

Fixes #13 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have done the work for both react and vue
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (Storybook)
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
