### PR TITLE
fix: semicircle chart padding problem

### DIFF
--- a/packages/ez-react/src/recipes/pie/PieChart.stories.tsx
+++ b/packages/ez-react/src/recipes/pie/PieChart.stories.tsx
@@ -65,6 +65,12 @@ const defaultArguments = {
   colors,
   domainKey: 'value',
   data: rawData,
+  padding: {
+    left: 150,
+    bottom: 100,
+    right: 150,
+    top: 100,
+  },
 };
 
 Default.args = defaultArguments;


### PR DESCRIPTION
# Motivation

The padding prop is not responding correctly when tested out on react storybook, but it is working correctly in the vue storybooks, so we assumed that the problem came from the storybook and not the actual component in react. We added the padding configuration to the storybooks.

Fixes #27 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I have done the work for both react and vue
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (Storybook)
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
