### PR TITLE
Feat: resizable chart container

### DIFF
--- a/packages/ez-dev/jest/snapshots/components/addons/Tooltip.spec.tsx.snap
+++ b/packages/ez-dev/jest/snapshots/components/addons/Tooltip.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Tooltip renders no tooltip when shape is being hovered 1`] = `
 <div
   class="ez-tooltip"
-  style="left: 0px; top: 0px; opacity: 0;"
+  style="left: 416px; top: 284px; opacity: 0;"
 >
 </div>
 `;

--- a/packages/ez-react/src/components/Chart.tsx
+++ b/packages/ez-react/src/components/Chart.tsx
@@ -61,7 +61,6 @@ export const Chart: FC<ChartProps> = ({
   // Dimensions
   const chartRef = React.createRef<HTMLDivElement>();
   const { dimensions: parentDimensions } = useResponsiveChart();
-  // console.log(responsiveDimensions);
   const legendRef = React.useRef<HTMLDivElement | null>(null);
 
   const chartPadding: ChartPadding = useMemo(

--- a/packages/ez-react/src/components/Chart.tsx
+++ b/packages/ez-react/src/components/Chart.tsx
@@ -43,7 +43,7 @@ export type ChartProps = {
 };
 
 export const Chart: FC<ChartProps> = ({
-  dimensions = defaultChartDimensions,
+  dimensions,
   padding = {},
   animationOptions,
   scales,
@@ -72,6 +72,9 @@ export const Chart: FC<ChartProps> = ({
   );
 
   const containerDimensions: Dimensions = useMemo(
+    // We set the dimensions as provided in the props. Otherwise, we set the parent dimensions.
+    // At last, if width / height are equal to zero we default the dimensions
+    // so that the end-user would be able to see the chart.
     () => ({
       width:
         parentDimensions?.width ||

--- a/packages/ez-react/src/components/Chart.tsx
+++ b/packages/ez-react/src/components/Chart.tsx
@@ -13,13 +13,13 @@ import { Tooltip, TooltipProps } from '@/components/addons/tooltip/Tooltip';
 import { LegendPropsWithRef } from './addons/legend/Legend';
 import {
   AbstractScale,
-  debounce,
   defaultChartAnimationOptions,
   defaultChartDimensions,
   defaultChartPadding,
   normalizeData,
   transformTranslate,
 } from 'eazychart-core/src';
+import { useResponsiveChart } from '@/lib/use-responsive-chart';
 
 export type ChartProps = {
   padding?: Partial<ChartPadding>;
@@ -40,11 +40,10 @@ export type ChartProps = {
     idx: number
   ) => void;
   isWrapped?: boolean;
-  onResize?: (dimensions: Dimensions) => void;
 };
 
 export const Chart: FC<ChartProps> = ({
-  dimensions,
+  dimensions = defaultChartDimensions,
   padding = {},
   animationOptions,
   scales,
@@ -55,18 +54,15 @@ export const Chart: FC<ChartProps> = ({
   isRTL = false,
   onToggleDatum,
   isWrapped = true,
-  onResize,
 }) => {
   // Data
   const [dataDict, setDataDict] = useState(normalizeData(rawData, colors));
 
   // Dimensions
   const chartRef = React.createRef<HTMLDivElement>();
+  const { dimensions: parentDimensions } = useResponsiveChart();
+  // console.log(responsiveDimensions);
   const legendRef = React.useRef<HTMLDivElement | null>(null);
-  const [containerDimensions, setContainerDimensions] = useState<Dimensions>({
-    width: dimensions?.width || 0,
-    height: dimensions?.height || 0,
-  });
 
   const chartPadding: ChartPadding = useMemo(
     () => ({
@@ -74,6 +70,20 @@ export const Chart: FC<ChartProps> = ({
       ...padding,
     }),
     [padding]
+  );
+
+  const containerDimensions: Dimensions = useMemo(
+    () => ({
+      width:
+        parentDimensions?.width ||
+        dimensions?.width ||
+        defaultChartDimensions.width,
+      height:
+        parentDimensions?.height ||
+        dimensions?.height ||
+        defaultChartDimensions.height,
+    }),
+    [parentDimensions, dimensions]
   );
 
   const chartDimensions: Dimensions = useMemo(() => {
@@ -138,54 +148,6 @@ export const Chart: FC<ChartProps> = ({
       });
     }
   }, [activeData, chartDimensions, scales]);
-
-  const resizeChart: Function = (entries: ResizeObserverEntry[]) => {
-    entries.forEach((entry) => {
-      // We set the dimensions as provided in the props. Otherwise, we set the parent dimensions.
-      // At last, if width / height are equal to zero we default the dimensions
-      // so that the end-user would be able to see the chart.
-      const newDimensions = {
-        width:
-          dimensions?.width ||
-          Math.floor(entry.contentRect.width) ||
-          defaultChartDimensions.width,
-        height:
-          dimensions?.height ||
-          Math.floor(entry.contentRect.height) ||
-          defaultChartDimensions.height,
-      };
-      setContainerDimensions(newDimensions);
-      onResize && onResize(newDimensions);
-    });
-  };
-
-  // If dimensions prop is provided, we force the values
-  useEffect(() => {
-    const newDimensions = {
-      width: dimensions?.width || containerDimensions.width,
-      height: dimensions?.height || containerDimensions.height,
-    };
-    setContainerDimensions(newDimensions);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dimensions]);
-
-  // Else, observe chart parent width & height
-  useEffect(() => {
-    if (!dimensions?.width || !dimensions?.height) {
-      // Dimensions values has not been set, we need to observe and resize
-      const observer = new ResizeObserver((entries) => {
-        debounce(resizeChart(entries), 100);
-      });
-      observer.observe(chartRef.current?.parentNode as Element, {
-        box: 'border-box',
-      });
-      return () => {
-        observer.disconnect();
-      };
-    }
-    return;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   const toggleDatum = useCallback(
     (datum: NormalizedDatum, newState: boolean, idx: number) => {

--- a/packages/ez-react/src/components/ResponsiveChartContainer.tsx
+++ b/packages/ez-react/src/components/ResponsiveChartContainer.tsx
@@ -20,9 +20,6 @@ export const ResponsiveChartContainer: FC<ResponsiveChartContainerProps> = ({
 
   const resizeChart: Function = (entries: ResizeObserverEntry[]) => {
     entries.forEach((entry) => {
-      // We set the dimensions as provided in the props. Otherwise, we set the parent dimensions.
-      // At last, if width / height are equal to zero we default the dimensions
-      // so that the end-user would be able to see the chart.
       const newDimensions = {
         width:
           Math.floor(entry.contentRect.width) || defaultChartDimensions.width,

--- a/packages/ez-react/src/components/ResponsiveChartContainer.tsx
+++ b/packages/ez-react/src/components/ResponsiveChartContainer.tsx
@@ -1,0 +1,76 @@
+import React, { FC, useEffect, useState } from 'react';
+import { Dimensions } from 'eazychart-core/src/types';
+import { debounce, defaultChartDimensions } from 'eazychart-core/src';
+import { ResponsiveChartContext } from '@/lib/use-responsive-chart';
+
+export type ResponsiveChartContainerProps = {
+  dimensions?: Partial<Dimensions>;
+  onResize?: (dimensions: Dimensions) => void;
+};
+
+export const ResponsiveChartContainer: FC<ResponsiveChartContainerProps> = ({
+  children,
+  onResize,
+}) => {
+  // Dimensions
+  const containerRef = React.createRef<HTMLDivElement>();
+  const [containerDimensions, setContainerDimensions] = useState<Dimensions>({
+    width: 0,
+    height: 0,
+  });
+
+  const resizeChart: Function = (entries: ResizeObserverEntry[]) => {
+    entries.forEach((entry) => {
+      // We set the dimensions as provided in the props. Otherwise, we set the parent dimensions.
+      // At last, if width / height are equal to zero we default the dimensions
+      // so that the end-user would be able to see the chart.
+      const newDimensions = {
+        width:
+          containerDimensions?.width ||
+          Math.floor(entry.contentRect.width) ||
+          defaultChartDimensions.width,
+        height:
+          containerDimensions?.height ||
+          Math.floor(entry.contentRect.height) ||
+          defaultChartDimensions.height,
+      };
+      setContainerDimensions(newDimensions);
+      onResize && onResize(newDimensions);
+    });
+  };
+
+  // If dimensions prop is provided, we force the values
+  useEffect(() => {
+    const newDimensions = {
+      width: containerDimensions.width,
+      height: containerDimensions.height,
+    };
+    setContainerDimensions(newDimensions);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Else, observe chart parent width & height
+  useEffect(() => {
+    // Dimensions values has not been set, we need to observe and resize
+    const observer = new ResizeObserver((entries) => {
+      debounce(resizeChart(entries), 100);
+    });
+    observer.observe(containerRef.current as Element, {
+      box: 'border-box',
+    });
+    return () => {
+      observer.disconnect();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <ResponsiveChartContext.Provider
+      value={{ dimensions: containerDimensions }}
+    >
+      <div style={{ width: '100%', height: '100%' }} ref={containerRef}>
+        {children}
+      </div>
+    </ResponsiveChartContext.Provider>
+  );
+};

--- a/packages/ez-react/src/components/ResponsiveChartContainer.tsx
+++ b/packages/ez-react/src/components/ResponsiveChartContainer.tsx
@@ -4,7 +4,6 @@ import { debounce, defaultChartDimensions } from 'eazychart-core/src';
 import { ResponsiveChartContext } from '@/lib/use-responsive-chart';
 
 export type ResponsiveChartContainerProps = {
-  dimensions?: Partial<Dimensions>;
   onResize?: (dimensions: Dimensions) => void;
 };
 

--- a/packages/ez-react/src/components/ResponsiveChartContainer.tsx
+++ b/packages/ez-react/src/components/ResponsiveChartContainer.tsx
@@ -25,28 +25,14 @@ export const ResponsiveChartContainer: FC<ResponsiveChartContainerProps> = ({
       // so that the end-user would be able to see the chart.
       const newDimensions = {
         width:
-          containerDimensions?.width ||
-          Math.floor(entry.contentRect.width) ||
-          defaultChartDimensions.width,
+          Math.floor(entry.contentRect.width) || defaultChartDimensions.width,
         height:
-          containerDimensions?.height ||
-          Math.floor(entry.contentRect.height) ||
-          defaultChartDimensions.height,
+          Math.floor(entry.contentRect.height) || defaultChartDimensions.height,
       };
       setContainerDimensions(newDimensions);
       onResize && onResize(newDimensions);
     });
   };
-
-  // If dimensions prop is provided, we force the values
-  useEffect(() => {
-    const newDimensions = {
-      width: containerDimensions.width,
-      height: containerDimensions.height,
-    };
-    setContainerDimensions(newDimensions);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   // Else, observe chart parent width & height
   useEffect(() => {
@@ -67,7 +53,11 @@ export const ResponsiveChartContainer: FC<ResponsiveChartContainerProps> = ({
     <ResponsiveChartContext.Provider
       value={{ dimensions: containerDimensions }}
     >
-      <div style={{ width: '100%', height: '100%' }} ref={containerRef}>
+      <div
+        className="ez-responsive-container"
+        style={{ width: '100%', height: '100%' }}
+        ref={containerRef}
+      >
         {children}
       </div>
     </ResponsiveChartContext.Provider>

--- a/packages/ez-react/src/lib/use-responsive-chart.ts
+++ b/packages/ez-react/src/lib/use-responsive-chart.ts
@@ -1,0 +1,12 @@
+import { Dimensions } from 'eazychart-core/src/types';
+import { createContext, useContext } from 'react';
+
+export const ResponsiveChartContext = createContext<{
+  dimensions?: Dimensions;
+}>({
+  dimensions: undefined,
+});
+
+export const useResponsiveChart = () => {
+  return useContext(ResponsiveChartContext);
+};

--- a/packages/ez-react/src/recipes/area/AreaChart.tsx
+++ b/packages/ez-react/src/recipes/area/AreaChart.tsx
@@ -37,7 +37,6 @@ export interface AreaChartProps extends SVGAttributes<SVGGElement> {
   scopedSlots?: {
     TooltipComponent?: FC<TooltipProps>;
   };
-  onResize?: (dimensions: Dimensions) => void;
 }
 
 export const AreaChart: FC<AreaChartProps> = ({
@@ -80,7 +79,6 @@ export const AreaChart: FC<AreaChartProps> = ({
   scopedSlots = {
     TooltipComponent: Tooltip,
   },
-  onResize,
 }) => {
   const horizontalAxis = swapAxis ? yAxis : xAxis;
   const verticalAxis = swapAxis ? xAxis : yAxis;
@@ -112,7 +110,6 @@ export const AreaChart: FC<AreaChartProps> = ({
       colors={[area.stroke]}
       animationOptions={animationOptions}
       scopedSlots={scopedSlots}
-      onResize={onResize}
     >
       <Grid
         directions={grid.directions}

--- a/packages/ez-react/src/recipes/bar/BarChart.stories.tsx
+++ b/packages/ez-react/src/recipes/bar/BarChart.stories.tsx
@@ -37,7 +37,7 @@ const TemplateWithParentDimensions: Story<BarChartProps> = (args) => {
       }}
     >
       <ResponsiveChartContainer>
-        <BarChart {...args} dimensions={{ width: 800, height: 600 }} />
+        <BarChart {...args} />
       </ResponsiveChartContainer>
     </ChartWrapper>
   );

--- a/packages/ez-react/src/recipes/bar/BarChart.stories.tsx
+++ b/packages/ez-react/src/recipes/bar/BarChart.stories.tsx
@@ -3,6 +3,7 @@ import { Meta, Story } from '@storybook/react';
 import { BarChart, BarChartProps } from '@/recipes/bar/BarChart';
 import { baseChartArgTypes, ChartWrapper } from '@/lib/storybook-utils';
 import { colors, dimensions, rawData } from 'eazychart-dev/storybook/data';
+import { ResponsiveChartContainer } from '@/components/ResponsiveChartContainer';
 
 const meta: Meta = {
   id: '3',
@@ -35,7 +36,9 @@ const TemplateWithParentDimensions: Story<BarChartProps> = (args) => {
         overflow: 'scroll',
       }}
     >
-      <BarChart {...args} />
+      <ResponsiveChartContainer>
+        <BarChart {...args} dimensions={{ width: 800, height: 600 }} />
+      </ResponsiveChartContainer>
     </ChartWrapper>
   );
 };

--- a/packages/ez-react/src/recipes/bar/BarChart.tsx
+++ b/packages/ez-react/src/recipes/bar/BarChart.tsx
@@ -31,7 +31,6 @@ export interface BarChartProps extends SVGAttributes<SVGGElement> {
     LegendComponent?: React.FC<LegendPropsWithRef>;
     TooltipComponent?: FC<TooltipProps>;
   };
-  onResize?: (dimensions: Dimensions) => void;
 }
 
 export const BarChart: FC<BarChartProps> = ({
@@ -66,7 +65,6 @@ export const BarChart: FC<BarChartProps> = ({
     LegendComponent: Legend,
     TooltipComponent: Tooltip,
   },
-  onResize,
 }) => {
   const xScale = useMemo<ScaleLinear>(
     () =>
@@ -97,7 +95,6 @@ export const BarChart: FC<BarChartProps> = ({
       animationOptions={animationOptions}
       scopedSlots={scopedSlots}
       isRTL={isRTL}
-      onResize={onResize}
     >
       <Grid
         directions={grid.directions}

--- a/packages/ez-react/src/recipes/column/ColumnChart.tsx
+++ b/packages/ez-react/src/recipes/column/ColumnChart.tsx
@@ -31,7 +31,6 @@ export interface ColumnChartProps extends SVGAttributes<SVGGElement> {
     LegendComponent: React.FC<LegendPropsWithRef>;
     TooltipComponent: React.FC<TooltipProps>;
   };
-  onResize?: (dimensions: Dimensions) => void;
 }
 
 export const ColumnChart: FC<ColumnChartProps> = ({
@@ -66,7 +65,6 @@ export const ColumnChart: FC<ColumnChartProps> = ({
     LegendComponent: Legend,
     TooltipComponent: Tooltip,
   },
-  onResize,
 }) => {
   const xScale = useMemo<ScaleBand>(
     () =>
@@ -96,7 +94,6 @@ export const ColumnChart: FC<ColumnChartProps> = ({
       animationOptions={animationOptions}
       scopedSlots={scopedSlots}
       isRTL={isRTL}
-      onResize={onResize}
     >
       <Grid
         directions={grid.directions}

--- a/packages/ez-react/src/recipes/column/LineColumnChart.tsx
+++ b/packages/ez-react/src/recipes/column/LineColumnChart.tsx
@@ -70,7 +70,6 @@ export const LineColumnChart: FC<LineColumnChartProps> = ({
     LegendComponent: Legend,
     TooltipComponent: Tooltip,
   },
-  onResize,
 }) => {
   const xColumnScale = useMemo<ScaleBand>(
     () =>
@@ -120,7 +119,6 @@ export const LineColumnChart: FC<LineColumnChartProps> = ({
       animationOptions={animationOptions}
       scopedSlots={scopedSlots}
       isRTL={isRTL}
-      onResize={onResize}
     >
       <Grid
         directions={grid.directions}

--- a/packages/ez-react/src/recipes/line/LineChart.tsx
+++ b/packages/ez-react/src/recipes/line/LineChart.tsx
@@ -35,7 +35,6 @@ export interface LineChartProps extends SVGAttributes<SVGGElement> {
   scopedSlots?: {
     TooltipComponent: FC<TooltipProps>;
   };
-  onResize?: (dimensions: Dimensions) => void;
 }
 
 export const LineChart: FC<LineChartProps> = ({
@@ -77,7 +76,6 @@ export const LineChart: FC<LineChartProps> = ({
   scopedSlots = {
     TooltipComponent: Tooltip,
   },
-  onResize,
 }) => {
   const horizontalAxis = swapAxis ? yAxis : xAxis;
   const verticalAxis = swapAxis ? xAxis : yAxis;
@@ -109,7 +107,6 @@ export const LineChart: FC<LineChartProps> = ({
       colors={[line.stroke]}
       animationOptions={animationOptions}
       scopedSlots={scopedSlots}
-      onResize={onResize}
     >
       <Grid
         directions={grid.directions}

--- a/packages/ez-react/src/recipes/pie/IrregularPieChart.tsx
+++ b/packages/ez-react/src/recipes/pie/IrregularPieChart.tsx
@@ -25,7 +25,6 @@ export interface IrregularPieChartProps extends SVGAttributes<SVGGElement> {
     LegendComponent: React.FC<LegendPropsWithRef>;
     TooltipComponent: React.FC<TooltipProps>;
   };
-  onResize?: (dimensions: Dimensions) => void;
 }
 
 export const IrregularPieChart: FC<IrregularPieChartProps> = ({
@@ -56,7 +55,6 @@ export const IrregularPieChart: FC<IrregularPieChartProps> = ({
     LegendComponent: Legend,
     TooltipComponent: Tooltip,
   },
-  onResize,
 }) => {
   const aScale = useMemo<ScaleLinear>(
     () =>
@@ -83,7 +81,6 @@ export const IrregularPieChart: FC<IrregularPieChartProps> = ({
       colors={colors}
       animationOptions={animationOptions}
       scopedSlots={scopedSlots}
-      onResize={onResize}
     >
       <IrregularArcs aScale={aScale} rScale={rScale} {...arc} />
     </Chart>

--- a/packages/ez-react/src/recipes/pie/PieChart.tsx
+++ b/packages/ez-react/src/recipes/pie/PieChart.tsx
@@ -25,7 +25,6 @@ export interface PieChartProps extends SVGAttributes<SVGGElement> {
     LegendComponent: React.FC<LegendPropsWithRef>;
     TooltipComponent: React.FC<TooltipProps>;
   };
-  onResize?: (dimensions: Dimensions) => void;
 }
 
 export const PieChart: FC<PieChartProps> = ({
@@ -56,7 +55,6 @@ export const PieChart: FC<PieChartProps> = ({
     LegendComponent: Legend,
     TooltipComponent: Tooltip,
   },
-  onResize,
 }) => {
   const scale = useMemo<ScaleLinear>(
     () =>
@@ -75,7 +73,6 @@ export const PieChart: FC<PieChartProps> = ({
       colors={colors}
       animationOptions={animationOptions}
       scopedSlots={scopedSlots}
-      onResize={onResize}
     >
       <Pie aScale={scale} {...arc} />
     </Chart>

--- a/packages/ez-react/src/recipes/pie/RadialChart.tsx
+++ b/packages/ez-react/src/recipes/pie/RadialChart.tsx
@@ -26,7 +26,6 @@ export interface RadialChartProps extends SVGAttributes<SVGGElement> {
     LegendComponent: React.FC<LegendPropsWithRef>;
     TooltipComponent: React.FC<TooltipProps>;
   };
-  onResize?: (dimensions: Dimensions) => void;
 }
 
 export const RadialChart: FC<RadialChartProps> = ({
@@ -55,7 +54,6 @@ export const RadialChart: FC<RadialChartProps> = ({
     LegendComponent: Legend,
     TooltipComponent: Tooltip,
   },
-  onResize,
 }) => {
   const scale = useMemo<ScaleLinear>(
     () =>
@@ -76,7 +74,6 @@ export const RadialChart: FC<RadialChartProps> = ({
         colors={colors}
         animationOptions={animationOptions}
         scopedSlots={scopedSlots}
-        onResize={onResize}
       >
         <Arcs arcScale={scale} {...arc} />
       </Chart>

--- a/packages/ez-react/src/recipes/pie/SemiCircleChart.tsx
+++ b/packages/ez-react/src/recipes/pie/SemiCircleChart.tsx
@@ -37,7 +37,6 @@ export const SemiCircleChart: FC<SemiCircleChartProps> = ({
     LegendComponent: Legend,
     TooltipComponent: Tooltip,
   },
-  onResize,
 }) => {
   const scale = useMemo<ScaleLinear>(
     () =>
@@ -56,7 +55,6 @@ export const SemiCircleChart: FC<SemiCircleChartProps> = ({
       colors={colors}
       animationOptions={animationOptions}
       scopedSlots={scopedSlots}
-      onResize={onResize}
     >
       <Pie
         aScale={scale}

--- a/packages/ez-react/src/recipes/scatter/BubbleChart.tsx
+++ b/packages/ez-react/src/recipes/scatter/BubbleChart.tsx
@@ -31,7 +31,6 @@ export interface BubbleChartProps extends SVGAttributes<SVGGElement> {
   scopedSlots?: {
     TooltipComponent: FC<TooltipProps>;
   };
-  onResize?: (dimensions: Dimensions) => void;
 }
 
 export const BubbleChart: FC<BubbleChartProps> = ({
@@ -69,7 +68,6 @@ export const BubbleChart: FC<BubbleChartProps> = ({
   scopedSlots = {
     TooltipComponent: Tooltip,
   },
-  onResize,
 }) => {
   const horizontalAxis = swapAxis ? yAxis : xAxis;
   const verticalAxis = swapAxis ? xAxis : yAxis;
@@ -109,7 +107,6 @@ export const BubbleChart: FC<BubbleChartProps> = ({
       colors={[bubble.fill]}
       animationOptions={animationOptions}
       scopedSlots={scopedSlots}
-      onResize={onResize}
     >
       <Grid
         directions={grid.directions}

--- a/packages/ez-react/src/recipes/scatter/ScatterChart.tsx
+++ b/packages/ez-react/src/recipes/scatter/ScatterChart.tsx
@@ -31,7 +31,6 @@ export interface ScatterChartProps extends SVGAttributes<SVGGElement> {
   scopedSlots?: {
     TooltipComponent: FC<TooltipProps>;
   };
-  onResize?: (dimensions: Dimensions) => void;
 }
 
 export const ScatterChart: FC<ScatterChartProps> = ({
@@ -67,7 +66,6 @@ export const ScatterChart: FC<ScatterChartProps> = ({
   scopedSlots = {
     TooltipComponent: Tooltip,
   },
-  onResize,
 }) => {
   const horizontalAxis = swapAxis ? yAxis : xAxis;
   const verticalAxis = swapAxis ? xAxis : yAxis;
@@ -99,7 +97,6 @@ export const ScatterChart: FC<ScatterChartProps> = ({
       colors={[point.color]}
       animationOptions={animationOptions}
       scopedSlots={scopedSlots}
-      onResize={onResize}
     >
       <Grid
         directions={grid.directions}

--- a/packages/ez-vue/src/components/Chart.tsx
+++ b/packages/ez-vue/src/components/Chart.tsx
@@ -107,12 +107,14 @@ export default class Chart extends Vue {
   created() {
     this.chart.dataDict = normalizeData(this.rawData, this.colors);
     const parentDimensions = this.responsiveChart?.dimensions;
+      // We set the dimensions as provided in the props. Otherwise, we set the parent dimensions.
+      // At last, if width / height are equal to zero we default the dimensions
+      // so that the end-user would be able to see the chart.
     this.containerDimensions = {
       width: this.dimensions?.width || parentDimensions?.width || defaultChartDimensions.width,
       height: this.dimensions?.height || parentDimensions?.height || defaultChartDimensions.height,
     };
   }
-
   mounted() {
     // Set legend height on mount and after data is populated
     this.$nextTick(() => {

--- a/packages/ez-vue/src/components/Chart.tsx
+++ b/packages/ez-vue/src/components/Chart.tsx
@@ -107,14 +107,15 @@ export default class Chart extends Vue {
   created() {
     this.chart.dataDict = normalizeData(this.rawData, this.colors);
     const parentDimensions = this.responsiveChart?.dimensions;
-      // We set the dimensions as provided in the props. Otherwise, we set the parent dimensions.
-      // At last, if width / height are equal to zero we default the dimensions
-      // so that the end-user would be able to see the chart.
+    // We set the dimensions as provided in the props. Otherwise, we set the parent dimensions.
+    // At last, if width / height are equal to zero we default the dimensions
+    // so that the end-user would be able to see the chart.
     this.containerDimensions = {
       width: this.dimensions?.width || parentDimensions?.width || defaultChartDimensions.width,
       height: this.dimensions?.height || parentDimensions?.height || defaultChartDimensions.height,
     };
   }
+
   mounted() {
     // Set legend height on mount and after data is populated
     this.$nextTick(() => {

--- a/packages/ez-vue/src/components/Chart.tsx
+++ b/packages/ez-vue/src/components/Chart.tsx
@@ -106,10 +106,10 @@ export default class Chart extends Vue {
 
   created() {
     this.chart.dataDict = normalizeData(this.rawData, this.colors);
-    const parentDimensions = this.responsiveChart.dimensions;
+    const parentDimensions = this.responsiveChart?.dimensions;
     this.containerDimensions = {
-      width: this.dimensions?.width || parentDimensions.width || defaultChartDimensions.width,
-      height: this.dimensions?.height || parentDimensions.height || defaultChartDimensions.height,
+      width: this.dimensions?.width || parentDimensions?.width || defaultChartDimensions.width,
+      height: this.dimensions?.height || parentDimensions?.height || defaultChartDimensions.height,
     };
   }
 
@@ -136,10 +136,10 @@ export default class Chart extends Vue {
   @Watch('responsiveChart.dimensions')
   onDimensionsChange() {
     // If dimensions prop is provided, we force the values
-    const parentDimensions = this.responsiveChart.dimensions;
+    const parentDimensions = this.responsiveChart?.dimensions;
     this.containerDimensions = {
-      width: this.dimensions?.width || parentDimensions.width,
-      height: this.dimensions?.height || parentDimensions.height,
+      width: this.dimensions?.width || parentDimensions?.width,
+      height: this.dimensions?.height || parentDimensions?.height,
     };
   }
 

--- a/packages/ez-vue/src/components/ResponsiveChartContainer.tsx
+++ b/packages/ez-vue/src/components/ResponsiveChartContainer.tsx
@@ -1,0 +1,74 @@
+import Vue, { PropType } from 'vue';
+import Component from 'vue-class-component';
+import { Prop, ProvideReactive } from 'vue-property-decorator';
+import { Dimensions } from 'eazychart-core/src/types';
+import { debounce, defaultChartDimensions } from 'eazychart-core/src';
+
+@Component
+export default class ResponsiveChartContainer extends Vue {
+  @Prop({
+    type: Function as PropType<(dimensions: Dimensions) => void>,
+  })
+  private readonly onResize?: (dimensions: Dimensions) => void;
+
+  private resizeObserver!: ResizeObserver;
+
+  @ProvideReactive('responsiveChart')
+  private responsiveChart: { dimensions: Dimensions } = {
+    dimensions: {
+      width: 0,
+      height: 0,
+    },
+  };
+
+  beforeDestroy() {
+    if (this.resizeObserver) {
+      this.resizeObserver.disconnect();
+    }
+  }
+
+  mounted() {
+    // Dimensions values has not been set, we need to observe and resize
+    this.resizeObserver = new ResizeObserver(
+      debounce((entries: ResizeObserverEntry[]) => {
+        this.resizeChart(entries);
+      }, 100),
+    );
+    const chartRef = this.$refs.responsiveContainer as Node;
+    this.resizeObserver.observe(chartRef as Element, {
+      box: 'border-box',
+    });
+  }
+
+  resizeChart(entries: ResizeObserverEntry[]) {
+    entries.forEach((entry) => {
+      // We set the dimensions as provided in the props. Otherwise, we set the parent dimensions.
+      // At last, if width / height are equal to zero we default the dimensions
+      // so that the end-user would be able to see the chart.
+      const newDimensions = {
+        width:
+          Math.floor(entry.contentRect.width) || defaultChartDimensions.width,
+        height:
+          Math.floor(entry.contentRect.height) || defaultChartDimensions.height,
+      };
+      this.responsiveChart.dimensions = newDimensions;
+      this.onResize && this.onResize(newDimensions);
+    });
+  }
+
+  render() {
+    const DefaultSlot = this.$scopedSlots.default
+      ? this.$scopedSlots.default({})
+      : null;
+
+    return (
+      <div
+        class="ez-responsive-container"
+        style={{ width: '100%', height: '100%' }}
+        ref="responsiveContainer"
+      >
+        {DefaultSlot}
+      </div>
+    );
+  }
+}

--- a/packages/ez-vue/src/components/ResponsiveChartContainer.tsx
+++ b/packages/ez-vue/src/components/ResponsiveChartContainer.tsx
@@ -42,9 +42,6 @@ export default class ResponsiveChartContainer extends Vue {
 
   resizeChart(entries: ResizeObserverEntry[]) {
     entries.forEach((entry) => {
-      // We set the dimensions as provided in the props. Otherwise, we set the parent dimensions.
-      // At last, if width / height are equal to zero we default the dimensions
-      // so that the end-user would be able to see the chart.
       const newDimensions = {
         width:
           Math.floor(entry.contentRect.width) || defaultChartDimensions.width,

--- a/packages/ez-vue/src/recipes/area/AreaChart.tsx
+++ b/packages/ez-vue/src/recipes/area/AreaChart.tsx
@@ -151,12 +151,6 @@ export default class AreaChart extends Vue {
   })
   private readonly isRTL!: boolean;
 
-  @Prop({
-    type: Function as PropType<(dimensions: Dimensions) => void>,
-    required: false,
-  })
-  private readonly onResize?: (dimensions: Dimensions) => void;
-
   get horizontalAxis() {
     return this.swapAxis ? this.yAxis : this.xAxis;
   }
@@ -197,7 +191,6 @@ export default class AreaChart extends Vue {
       animationOptions,
       grid,
       isRTL,
-      onResize,
       $scopedSlots,
       dimensions,
     } = this;
@@ -212,7 +205,6 @@ export default class AreaChart extends Vue {
         animationOptions={animationOptions}
         scopedSlots={$scopedSlots}
         isRTL={isRTL}
-        onResize={onResize}
       >
         <Grid
           directions={grid.directions}

--- a/packages/ez-vue/src/recipes/bar/BarChart.stories.tsx
+++ b/packages/ez-vue/src/recipes/bar/BarChart.stories.tsx
@@ -5,8 +5,12 @@ import {
   ResizableChartWrapper,
 } from '@/lib/storybook-utils';
 import {
-  animationOptions, colors, dimensions, rawData,
+  animationOptions,
+  colors,
+  dimensions,
+  rawData,
 } from 'eazychart-dev/storybook/data';
+import ResponsiveChartContainer from '@/components/ResponsiveChartContainer';
 import BarChart from './BarChart';
 
 const meta: Meta = {
@@ -32,11 +36,13 @@ const DefaultTemplate: Story = (_args, { argTypes }) => ({
 
 const TemplateWithParentDimensions: Story = (_args, { argTypes }) => ({
   title: 'Withparent',
-  components: { BarChart, ResizableChartWrapper },
+  components: { BarChart, ResizableChartWrapper, ResponsiveChartContainer },
   props: Object.keys(argTypes),
   template: `
     <ResizableChartWrapper>
-      <BarChart v-bind="$props" />
+      <ResponsiveChartContainer>
+        <BarChart v-bind="$props" />
+      </ResponsiveChartContainer>
     </ResizableChartWrapper>
   `,
 });

--- a/packages/ez-vue/src/recipes/bar/BarChart.tsx
+++ b/packages/ez-vue/src/recipes/bar/BarChart.tsx
@@ -118,16 +118,6 @@ export default class BarChart extends Vue {
   })
   private readonly isRTL!: boolean;
 
-  @Prop({
-    type: Function as PropType<
-      (dimensions: Dimensions) => void
-    >,
-    required: false,
-  })
-  private readonly onResize?: (
-    dimensions: Dimensions,
-  ) => void;
-
   private xScale!: ScaleLinear;
 
   private yScale!: ScaleBand;
@@ -158,7 +148,6 @@ export default class BarChart extends Vue {
       animationOptions,
       grid,
       isRTL,
-      onResize,
       $scopedSlots,
       dimensions,
     } = this;
@@ -181,7 +170,6 @@ export default class BarChart extends Vue {
         animationOptions={animationOptions}
         scopedSlots={scopedSlots}
         isRTL={isRTL}
-        onResize={onResize}
       >
         <Grid
           directions={grid.directions}

--- a/packages/ez-vue/src/recipes/column/ColumnChart.tsx
+++ b/packages/ez-vue/src/recipes/column/ColumnChart.tsx
@@ -118,16 +118,6 @@ export default class ColumnChart extends Vue {
   })
   private readonly isRTL!: boolean;
 
-  @Prop({
-    type: Function as PropType<
-      (dimensions: Dimensions) => void
-    >,
-    required: false,
-  })
-  private readonly onResize?: (
-    dimensions: Dimensions,
-  ) => void;
-
   private xScale!: ScaleBand;
 
   private yScale!: ScaleLinear;
@@ -157,7 +147,6 @@ export default class ColumnChart extends Vue {
       animationOptions,
       grid,
       isRTL,
-      onResize,
       $scopedSlots,
       dimensions,
     } = this;
@@ -177,7 +166,6 @@ export default class ColumnChart extends Vue {
         animationOptions={animationOptions}
         scopedSlots={scopedSlots}
         isRTL={isRTL}
-        onResize={onResize}
       >
         <Grid
           directions={grid.directions}

--- a/packages/ez-vue/src/recipes/column/LineColumnChart.tsx
+++ b/packages/ez-vue/src/recipes/column/LineColumnChart.tsx
@@ -162,16 +162,6 @@ export default class LineColumnChart extends Vue {
   })
   private readonly isRTL!: boolean;
 
-  @Prop({
-    type: Function as PropType<
-      (dimensions: Dimensions) => void
-    >,
-    required: false,
-  })
-  private readonly onResize?: (
-    dimensions: Dimensions,
-  ) => void;
-
   private xColumnScale!: ScaleBand;
 
   private yColumnScale!: ScaleLinear;
@@ -224,7 +214,6 @@ export default class LineColumnChart extends Vue {
       animationOptions,
       grid,
       isRTL,
-      onResize,
       $scopedSlots,
       dimensions,
     } = this;
@@ -244,7 +233,6 @@ export default class LineColumnChart extends Vue {
         animationOptions={animationOptions}
         scopedSlots={scopedSlots}
         isRTL={isRTL}
-        onResize={onResize}
       >
         <Grid
           directions={grid.directions}

--- a/packages/ez-vue/src/recipes/line/LineChart.tsx
+++ b/packages/ez-vue/src/recipes/line/LineChart.tsx
@@ -147,16 +147,6 @@ export default class LineChart extends Vue {
   })
   private readonly isRTL!: boolean;
 
-  @Prop({
-    type: Function as PropType<
-      (dimensions: Dimensions) => void
-    >,
-    required: false,
-  })
-  private readonly onResize?: (
-    dimensions: Dimensions,
-  ) => void;
-
   get horizontalAxis() {
     return this.swapAxis ? this.yAxis : this.xAxis;
   }
@@ -197,7 +187,6 @@ export default class LineChart extends Vue {
       animationOptions,
       grid,
       isRTL,
-      onResize,
       $scopedSlots,
       dimensions,
     } = this;
@@ -212,7 +201,6 @@ export default class LineChart extends Vue {
         animationOptions={animationOptions}
         scopedSlots={$scopedSlots}
         isRTL={isRTL}
-        onResize={onResize}
       >
         <Grid
           directions={grid.directions}

--- a/packages/ez-vue/src/recipes/line/LineErrorMarginChart.tsx
+++ b/packages/ez-vue/src/recipes/line/LineErrorMarginChart.tsx
@@ -172,16 +172,6 @@ export default class LineErrorMarginChart extends Vue {
   })
   private readonly isRTL!: boolean;
 
-  @Prop({
-    type: Function as PropType<
-      (dimensions: Dimensions) => void
-    >,
-    required: false,
-  })
-  private readonly onResize?: (
-    dimensions: Dimensions,
-  ) => void;
-
   get horizontalAxis() {
     return this.swapAxis ? this.yAxis : this.xAxis;
   }
@@ -239,7 +229,6 @@ export default class LineErrorMarginChart extends Vue {
       animationOptions,
       grid,
       isRTL,
-      onResize,
       $scopedSlots,
       dimensions,
     } = this;
@@ -254,7 +243,6 @@ export default class LineErrorMarginChart extends Vue {
         animationOptions={animationOptions}
         scopedSlots={$scopedSlots}
         isRTL={isRTL}
-        onResize={onResize}
       >
         <Grid
           directions={grid.directions}

--- a/packages/ez-vue/src/recipes/pie/IrregularPieChart.tsx
+++ b/packages/ez-vue/src/recipes/pie/IrregularPieChart.tsx
@@ -93,12 +93,6 @@ export default class IrregularPieChart extends Vue {
   })
   private readonly arc!: PieConfig;
 
-  @Prop({
-    type: Function as PropType<(dimensions: Dimensions) => void>,
-    required: false,
-  })
-  private readonly onResize?: (dimensions: Dimensions) => void;
-
   private aScale!: ScaleLinear;
 
   private rScale!: ScaleLinear;
@@ -123,7 +117,6 @@ export default class IrregularPieChart extends Vue {
       colors,
       animationOptions,
       arc,
-      onResize,
       $scopedSlots,
       dimensions,
     } = this;
@@ -142,7 +135,6 @@ export default class IrregularPieChart extends Vue {
         colors={colors}
         animationOptions={animationOptions}
         scopedSlots={scopedSlots}
-        onResize={onResize}
       >
         <IrregularArcs
           aScale={aScale}

--- a/packages/ez-vue/src/recipes/pie/PieChart.tsx
+++ b/packages/ez-vue/src/recipes/pie/PieChart.tsx
@@ -93,16 +93,6 @@ export default class PieChart extends Vue {
   })
   private readonly arc!: PieConfig;
 
-  @Prop({
-    type: Function as PropType<
-      (dimensions: Dimensions) => void
-    >,
-    required: false,
-  })
-  private readonly onResize?: (
-    dimensions: Dimensions,
-  ) => void;
-
   private scale!: ScaleLinear;
 
   created() {
@@ -120,7 +110,6 @@ export default class PieChart extends Vue {
       colors,
       animationOptions,
       arc,
-      onResize,
       $scopedSlots,
       dimensions,
     } = this;
@@ -139,7 +128,6 @@ export default class PieChart extends Vue {
         colors={colors}
         animationOptions={animationOptions}
         scopedSlots={scopedSlots}
-        onResize={onResize}
       >
         <Pie
           aScale={scale}

--- a/packages/ez-vue/src/recipes/pie/RadialChart.tsx
+++ b/packages/ez-vue/src/recipes/pie/RadialChart.tsx
@@ -91,12 +91,6 @@ export default class RadialChart extends Vue {
   })
   private readonly arc!: RadialConfig;
 
-  @Prop({
-    type: Function as PropType<(dimensions: Dimensions) => void>,
-    required: false,
-  })
-  private readonly onResize?: (dimensions: Dimensions) => void;
-
   private scale!: ScaleLinear;
 
   created() {
@@ -115,7 +109,6 @@ export default class RadialChart extends Vue {
       colors,
       animationOptions,
       arc,
-      onResize,
       $scopedSlots,
       dimensions,
     } = this;
@@ -134,7 +127,6 @@ export default class RadialChart extends Vue {
         colors={colors}
         animationOptions={animationOptions}
         scopedSlots={scopedSlots}
-        onResize={onResize}
       >
         <Arcs
           arcScale={scale}

--- a/packages/ez-vue/src/recipes/pie/SemiCircleChart.tsx
+++ b/packages/ez-vue/src/recipes/pie/SemiCircleChart.tsx
@@ -93,12 +93,6 @@ export default class SemiCircleChart extends Vue {
   })
   private readonly arc!: PieConfig;
 
-  @Prop({
-    type: Function as PropType<(dimensions: Dimensions) => void>,
-    required: false,
-  })
-  private readonly onResize?: (dimensions: Dimensions) => void;
-
   private scale!: ScaleLinear;
 
   created() {
@@ -116,7 +110,6 @@ export default class SemiCircleChart extends Vue {
       colors,
       animationOptions,
       arc,
-      onResize,
       $scopedSlots,
       dimensions,
     } = this;
@@ -135,7 +128,6 @@ export default class SemiCircleChart extends Vue {
         colors={colors}
         animationOptions={animationOptions}
         scopedSlots={scopedSlots}
-        onResize={onResize}
       >
         <Pie
           getCenter={({ width, height }: Dimensions) => ({

--- a/packages/ez-vue/src/recipes/scatter/BubbleChart.tsx
+++ b/packages/ez-vue/src/recipes/scatter/BubbleChart.tsx
@@ -137,9 +137,6 @@ export default class BubbleChart extends Vue {
     >,
     required: false,
   })
-  private readonly onResize?: (
-    dimensions: Dimensions,
-  ) => void;
 
   get horizontalAxis() {
     return this.swapAxis ? this.yAxis : this.xAxis;
@@ -188,7 +185,6 @@ export default class BubbleChart extends Vue {
       animationOptions,
       grid,
       isRTL,
-      onResize,
       $scopedSlots,
       dimensions,
     } = this;
@@ -203,7 +199,6 @@ export default class BubbleChart extends Vue {
         animationOptions={animationOptions}
         scopedSlots={$scopedSlots}
         isRTL={isRTL}
-        onResize={onResize}
       >
         <Grid
           directions={grid.directions}

--- a/packages/ez-vue/src/recipes/scatter/ScatterChart.tsx
+++ b/packages/ez-vue/src/recipes/scatter/ScatterChart.tsx
@@ -129,15 +129,6 @@ export default class ScatterChart extends Vue {
   })
   private readonly isRTL!: boolean;
 
-  @Prop({
-    type: Function as PropType<
-      (dimensions: Dimensions) => void
-    >,
-  })
-  private readonly onResize?: (
-    dimensions: Dimensions,
-  ) => void;
-
   get horizontalAxis() {
     return this.swapAxis ? this.yAxis : this.xAxis;
   }
@@ -177,7 +168,6 @@ export default class ScatterChart extends Vue {
       animationOptions,
       grid,
       isRTL,
-      onResize,
       $scopedSlots,
       dimensions,
     } = this;
@@ -192,7 +182,6 @@ export default class ScatterChart extends Vue {
         animationOptions={animationOptions}
         scopedSlots={$scopedSlots}
         isRTL={isRTL}
-        onResize={onResize}
       >
         <Grid
           directions={grid.directions}

--- a/packages/ez-vue/tests/unit/components/addons/Tooltip.spec.tsx
+++ b/packages/ez-vue/tests/unit/components/addons/Tooltip.spec.tsx
@@ -10,6 +10,7 @@ describe('Tooltip', () => {
       propsData: {
         datum: null,
         shapeDatum: null,
+        mousePosition: { x: 400, y: 300 },
         isVisible: false,
         domains: ['label', 'value'],
         animationOptions: {

--- a/packages/ez-vue/tests/unit/recipes/area/AreaChart.spec.tsx
+++ b/packages/ez-vue/tests/unit/recipes/area/AreaChart.spec.tsx
@@ -11,7 +11,6 @@ describe('AreaChart', () => {
   it('renders an area chart', async () => {
     const wrapper = render(AreaChart, {
       propsData: {
-        onResize: () => undefined,
         data: pointsData as unknown as RawData,
         area: {
           stroke: 'red',

--- a/packages/ez-vue/tests/unit/recipes/bar/BarChart.spec.tsx
+++ b/packages/ez-vue/tests/unit/recipes/bar/BarChart.spec.tsx
@@ -10,7 +10,6 @@ describe('BarChart', () => {
   it('renders a bar chart', async () => {
     const wrapper = render(BarChart, {
       propsData: {
-        onResize: () => undefined,
         data: rawData,
         colors,
         grid: { directions: [] },

--- a/packages/ez-vue/tests/unit/recipes/column/ColumnChart.spec.tsx
+++ b/packages/ez-vue/tests/unit/recipes/column/ColumnChart.spec.tsx
@@ -10,7 +10,6 @@ describe('ColumnChart', () => {
   it('renders a column chart', async () => {
     const wrapper = render(ColumnChart, {
       propsData: {
-        onResize: () => undefined,
         data: rawData,
         colors,
         grid: { directions: [] },

--- a/packages/ez-vue/tests/unit/recipes/column/LineColumnChart.spec.tsx
+++ b/packages/ez-vue/tests/unit/recipes/column/LineColumnChart.spec.tsx
@@ -10,7 +10,6 @@ describe('LineColumnChart', () => {
   it('renders a line & column chart', async () => {
     const wrapper = render(LineColumnChart, {
       propsData: {
-        onResize: () => undefined,
         data: rawData,
         colors,
         grid: { directions: [] },

--- a/packages/ez-vue/tests/unit/recipes/line/LineChart.spec.tsx
+++ b/packages/ez-vue/tests/unit/recipes/line/LineChart.spec.tsx
@@ -11,7 +11,6 @@ describe('LineChart', () => {
   it('renders a line chart', async () => {
     const wrapper = render(LineChart, {
       propsData: {
-        onResize: () => undefined,
         data: pointsData as unknown as RawData,
         line: {
           stroke: 'red',

--- a/packages/ez-vue/tests/unit/recipes/line/LineErrorMarginChart.spec.tsx
+++ b/packages/ez-vue/tests/unit/recipes/line/LineErrorMarginChart.spec.tsx
@@ -10,7 +10,6 @@ describe('LineErrorMarginChart', () => {
   it('renders a line error margin chart', async () => {
     const wrapper = render(LineErrorMarginChart, {
       propsData: {
-        onResize: () => undefined,
         data: pointsWithMarginData,
         line: {
           stroke: 'red',

--- a/packages/ez-vue/tests/unit/recipes/pie/IrregularPieChart.spec.tsx
+++ b/packages/ez-vue/tests/unit/recipes/pie/IrregularPieChart.spec.tsx
@@ -9,7 +9,6 @@ import 'tests/mocks/ResizeObserver';
 describe('IrregularPieChart', () => {
   it('renders a irregular pie chart', async () => {
     const propsData = {
-      onResize: () => undefined,
       data: rawData,
       colors,
       dimensions,

--- a/packages/ez-vue/tests/unit/recipes/pie/PieChart.spec.tsx
+++ b/packages/ez-vue/tests/unit/recipes/pie/PieChart.spec.tsx
@@ -9,7 +9,6 @@ import 'tests/mocks/ResizeObserver';
 describe('PieChart', () => {
   it('renders a pie chart', async () => {
     const propsData = {
-      onResize: () => undefined,
       data: rawData,
       colors,
       dimensions,

--- a/packages/ez-vue/tests/unit/recipes/pie/RadialChart.spec.tsx
+++ b/packages/ez-vue/tests/unit/recipes/pie/RadialChart.spec.tsx
@@ -9,7 +9,6 @@ import 'tests/mocks/ResizeObserver';
 describe('RadialChart', () => {
   it('renders a Radial chart', async () => {
     const propsData = {
-      onResize: () => undefined,
       data: rawData,
       colors,
       dimensions,

--- a/packages/ez-vue/tests/unit/recipes/pie/SemiCircleChart.spec.tsx
+++ b/packages/ez-vue/tests/unit/recipes/pie/SemiCircleChart.spec.tsx
@@ -8,7 +8,6 @@ import 'tests/mocks/ResizeObserver';
 describe('SemiCircleChart', () => {
   it('renders a semi-circle chart', async () => {
     const propsData = {
-      onResize: () => undefined,
       data: rawData,
       colors,
       dimensions,

--- a/packages/ez-vue/tests/unit/recipes/scatter/BubbleChart.spec.tsx
+++ b/packages/ez-vue/tests/unit/recipes/scatter/BubbleChart.spec.tsx
@@ -8,7 +8,6 @@ import 'tests/mocks/ResizeObserver';
 describe('BubbleChart', () => {
   it('renders a bubble chart', async () => {
     const propsData = {
-      onResize: () => undefined,
       data: rawData,
       bubble: {
         domainKey: 'amount',

--- a/packages/ez-vue/tests/unit/recipes/scatter/ScatterChart.spec.tsx
+++ b/packages/ez-vue/tests/unit/recipes/scatter/ScatterChart.spec.tsx
@@ -8,7 +8,6 @@ import 'tests/mocks/ResizeObserver';
 describe('ScatterChart', () => {
   it('renders a scatter chart', async () => {
     const propsData = {
-      onResize: () => undefined,
       data: rawData,
       point: {
         radius: 6,


### PR DESCRIPTION
# Motivation
This PR adds a responsive container wrapper component (HOC). This container will be used mainly when a developer wants to add a responsive chart to his project. The developer can use the chart without the responsive container is he wishes to have a chart with fixed dimensions.

We created a new component that acts like a context provider. This component called `ResponsiveChartContainer` has a `ResisableObserver` class that will listen to the resize event, and it will provide the size of the container to the child component, mainly, the `Chart` context provider. 
We made sure that both Vue and React `ResponsiveChartContainer` have the same behavior.
 
Fixes #12
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] I have done the work for both React and Vue
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (Storybook)
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
