### PR TITLE
fix: areachart missing tickSize prop

### DIFF
--- a/packages/ez-react/src/recipes/area/AreaChart.tsx
+++ b/packages/ez-react/src/recipes/area/AreaChart.tsx
@@ -162,19 +162,26 @@ export const AreaChart: FC<AreaChartProps> = ({
         }}
       />
       <Axis
-        {...{
-          ...horizontalAxis,
-          aScale: xScale,
-          position: horizontalAxis.position || Position.BOTTOM,
-        }}
+        position={horizontalAxis.position || Position.BOTTOM}
+        aScale={xScale}
+        title={horizontalAxis.title}
+        titleAlign={horizontalAxis.titleAlign}
+        tickLength={horizontalAxis.tickLength}
+        tickCount={horizontalAxis.tickCount}
+        tickSize={horizontalAxis.tickSize}
+        tickFormat={horizontalAxis.tickFormat}
       />
       <Axis
-        {...{
-          ...verticalAxis,
-          aScale: yScale,
-          position:
-            verticalAxis.position || (isRTL ? Position.RIGHT : Position.LEFT),
-        }}
+        position={
+          verticalAxis.position || (isRTL ? Position.RIGHT : Position.LEFT)
+        }
+        aScale={yScale}
+        title={verticalAxis.title}
+        titleAlign={verticalAxis.titleAlign}
+        tickLength={verticalAxis.tickLength}
+        tickCount={verticalAxis.tickCount}
+        tickSize={verticalAxis.tickSize}
+        tickFormat={verticalAxis.tickFormat}
       />
     </Chart>
   );

--- a/packages/ez-react/src/recipes/area/AreaChart.tsx
+++ b/packages/ez-react/src/recipes/area/AreaChart.tsx
@@ -168,7 +168,7 @@ export const AreaChart: FC<AreaChartProps> = ({
         titleAlign={horizontalAxis.titleAlign}
         tickLength={horizontalAxis.tickLength}
         tickCount={horizontalAxis.tickCount}
-        tickSize={horizontalAxis.tickLength}
+        tickSize={horizontalAxis.tickSize}
         tickFormat={horizontalAxis.tickFormat}
       />
       <Axis
@@ -180,7 +180,7 @@ export const AreaChart: FC<AreaChartProps> = ({
         titleAlign={verticalAxis.titleAlign}
         tickLength={verticalAxis.tickLength}
         tickCount={verticalAxis.tickCount}
-        tickSize={verticalAxis.tickLength}
+        tickSize={verticalAxis.tickSize}
         tickFormat={verticalAxis.tickFormat}
       />
     </Chart>

--- a/packages/ez-react/src/recipes/area/AreaChart.tsx
+++ b/packages/ez-react/src/recipes/area/AreaChart.tsx
@@ -101,6 +101,7 @@ export const AreaChart: FC<AreaChartProps> = ({
       }),
     [verticalAxis]
   );
+
   return (
     <Chart
       dimensions={dimensions}
@@ -162,26 +163,16 @@ export const AreaChart: FC<AreaChartProps> = ({
         }}
       />
       <Axis
-        position={horizontalAxis.position || Position.BOTTOM}
+        {...horizontalAxis}
         aScale={xScale}
-        title={horizontalAxis.title}
-        titleAlign={horizontalAxis.titleAlign}
-        tickLength={horizontalAxis.tickLength}
-        tickCount={horizontalAxis.tickCount}
-        tickSize={horizontalAxis.tickSize}
-        tickFormat={horizontalAxis.tickFormat}
+        position={horizontalAxis.position || Position.BOTTOM}
       />
       <Axis
+        {...verticalAxis}
+        aScale={yScale}
         position={
           verticalAxis.position || (isRTL ? Position.RIGHT : Position.LEFT)
         }
-        aScale={yScale}
-        title={verticalAxis.title}
-        titleAlign={verticalAxis.titleAlign}
-        tickLength={verticalAxis.tickLength}
-        tickCount={verticalAxis.tickCount}
-        tickSize={verticalAxis.tickSize}
-        tickFormat={verticalAxis.tickFormat}
       />
     </Chart>
   );

--- a/packages/ez-react/src/recipes/area/AreaChart.tsx
+++ b/packages/ez-react/src/recipes/area/AreaChart.tsx
@@ -162,26 +162,19 @@ export const AreaChart: FC<AreaChartProps> = ({
         }}
       />
       <Axis
-        position={horizontalAxis.position || Position.BOTTOM}
-        aScale={xScale}
-        title={horizontalAxis.title}
-        titleAlign={horizontalAxis.titleAlign}
-        tickLength={horizontalAxis.tickLength}
-        tickCount={horizontalAxis.tickCount}
-        tickSize={horizontalAxis.tickSize}
-        tickFormat={horizontalAxis.tickFormat}
+        {...{
+          ...horizontalAxis,
+          aScale: xScale,
+          position: horizontalAxis.position || Position.BOTTOM,
+        }}
       />
       <Axis
-        position={
-          verticalAxis.position || (isRTL ? Position.RIGHT : Position.LEFT)
-        }
-        aScale={yScale}
-        title={verticalAxis.title}
-        titleAlign={verticalAxis.titleAlign}
-        tickLength={verticalAxis.tickLength}
-        tickCount={verticalAxis.tickCount}
-        tickSize={verticalAxis.tickSize}
-        tickFormat={verticalAxis.tickFormat}
+        {...{
+          ...verticalAxis,
+          aScale: yScale,
+          position:
+            verticalAxis.position || (isRTL ? Position.RIGHT : Position.LEFT),
+        }}
       />
     </Chart>
   );

--- a/packages/ez-react/src/recipes/bar/BarChart.tsx
+++ b/packages/ez-react/src/recipes/bar/BarChart.tsx
@@ -104,24 +104,14 @@ export const BarChart: FC<BarChartProps> = ({
       />
       <Bars xScale={xScale} yScale={yScale} />
       <Axis
+        {...xAxis}
         aScale={xScale}
         position={xAxis.position || Position.BOTTOM}
-        title={xAxis.title}
-        titleAlign={xAxis.titleAlign}
-        tickCount={xAxis.tickCount}
-        tickSize={xAxis.tickSize}
-        tickLength={xAxis.tickLength}
-        tickFormat={xAxis.tickFormat}
       />
       <Axis
+        {...yAxis}
         aScale={yScale}
         position={yAxis.position || (isRTL ? Position.RIGHT : Position.LEFT)}
-        title={yAxis.title}
-        titleAlign={yAxis.titleAlign}
-        tickCount={yAxis.tickCount}
-        tickSize={yAxis.tickSize}
-        tickLength={yAxis.tickLength}
-        tickFormat={yAxis.tickFormat}
       />
     </Chart>
   );

--- a/packages/ez-react/src/recipes/column/ColumnChart.tsx
+++ b/packages/ez-react/src/recipes/column/ColumnChart.tsx
@@ -103,24 +103,14 @@ export const ColumnChart: FC<ColumnChartProps> = ({
       />
       <Bars xScale={xScale} yScale={yScale} />
       <Axis
+        {...xAxis}
         aScale={xScale}
         position={xAxis.position || Position.BOTTOM}
-        title={xAxis.title}
-        titleAlign={xAxis.titleAlign}
-        tickCount={xAxis.tickCount}
-        tickSize={xAxis.tickSize}
-        tickLength={xAxis.tickLength}
-        tickFormat={xAxis.tickFormat}
       />
       <Axis
+        {...yAxis}
         aScale={yScale}
         position={yAxis.position || (isRTL ? Position.RIGHT : Position.LEFT)}
-        title={yAxis.title}
-        titleAlign={yAxis.titleAlign}
-        tickCount={yAxis.tickCount}
-        tickSize={yAxis.tickSize}
-        tickLength={yAxis.tickLength}
-        tickFormat={yAxis.tickFormat}
       />
     </Chart>
   );

--- a/packages/ez-react/src/recipes/column/LineColumnChart.tsx
+++ b/packages/ez-react/src/recipes/column/LineColumnChart.tsx
@@ -160,36 +160,21 @@ export const LineColumnChart: FC<LineColumnChartProps> = ({
         }}
       />
       <Axis
+        {...xAxis}
         aScale={xColumnScale}
         position={xAxis.position || Position.BOTTOM}
-        title={xAxis.title}
-        titleAlign={xAxis.titleAlign}
-        tickCount={xAxis.tickCount}
-        tickSize={xAxis.tickSize}
-        tickLength={xAxis.tickLength}
-        tickFormat={xAxis.tickFormat}
       />
       <Axis
+        {...yAxis}
         aScale={yColumnScale}
         position={yAxis.position || (isRTL ? Position.RIGHT : Position.LEFT)}
-        title={yAxis.title}
-        titleAlign={yAxis.titleAlign}
-        tickCount={yAxis.tickCount}
-        tickSize={yAxis.tickSize}
-        tickLength={yAxis.tickLength}
-        tickFormat={yAxis.tickFormat}
       />
       <Axis
+        {...yLineAxis}
         aScale={yLineScale}
         position={
           yLineAxis.position || (isRTL ? Position.LEFT : Position.RIGHT)
         }
-        title={yLineAxis.title}
-        titleAlign={yLineAxis.titleAlign}
-        tickCount={yLineAxis.tickCount}
-        tickSize={yLineAxis.tickSize}
-        tickLength={yLineAxis.tickLength}
-        tickFormat={yLineAxis.tickFormat}
       />
     </Chart>
   );

--- a/packages/ez-react/src/recipes/line/LineChart.tsx
+++ b/packages/ez-react/src/recipes/line/LineChart.tsx
@@ -146,26 +146,16 @@ export const LineChart: FC<LineChartProps> = ({
         }}
       />
       <Axis
-        position={horizontalAxis.position || Position.BOTTOM}
+        {...horizontalAxis}
         aScale={xScale}
-        title={horizontalAxis.title}
-        titleAlign={horizontalAxis.titleAlign}
-        tickLength={horizontalAxis.tickLength}
-        tickCount={horizontalAxis.tickCount}
-        tickSize={horizontalAxis.tickSize}
-        tickFormat={horizontalAxis.tickFormat}
+        position={horizontalAxis.position || Position.BOTTOM}
       />
       <Axis
+        {...verticalAxis}
+        aScale={yScale}
         position={
           verticalAxis.position || (isRTL ? Position.RIGHT : Position.LEFT)
         }
-        aScale={yScale}
-        title={verticalAxis.title}
-        titleAlign={verticalAxis.titleAlign}
-        tickLength={verticalAxis.tickLength}
-        tickCount={verticalAxis.tickCount}
-        tickSize={verticalAxis.tickSize}
-        tickFormat={verticalAxis.tickFormat}
       />
     </Chart>
   );

--- a/packages/ez-react/src/recipes/line/LineChart.tsx
+++ b/packages/ez-react/src/recipes/line/LineChart.tsx
@@ -146,26 +146,19 @@ export const LineChart: FC<LineChartProps> = ({
         }}
       />
       <Axis
-        position={horizontalAxis.position || Position.BOTTOM}
-        aScale={xScale}
-        title={horizontalAxis.title}
-        titleAlign={horizontalAxis.titleAlign}
-        tickLength={horizontalAxis.tickLength}
-        tickCount={horizontalAxis.tickCount}
-        tickSize={horizontalAxis.tickLength}
-        tickFormat={horizontalAxis.tickFormat}
+        {...{
+          ...horizontalAxis,
+          aScale: xScale,
+          position: horizontalAxis.position || Position.BOTTOM,
+        }}
       />
       <Axis
-        position={
-          verticalAxis.position || (isRTL ? Position.RIGHT : Position.LEFT)
-        }
-        aScale={yScale}
-        title={verticalAxis.title}
-        titleAlign={verticalAxis.titleAlign}
-        tickLength={verticalAxis.tickLength}
-        tickCount={verticalAxis.tickCount}
-        tickSize={verticalAxis.tickSize}
-        tickFormat={verticalAxis.tickFormat}
+        {...{
+          ...verticalAxis,
+          aScale: yScale,
+          position:
+            verticalAxis.position || (isRTL ? Position.RIGHT : Position.LEFT),
+        }}
       />
     </Chart>
   );

--- a/packages/ez-react/src/recipes/line/LineChart.tsx
+++ b/packages/ez-react/src/recipes/line/LineChart.tsx
@@ -146,19 +146,26 @@ export const LineChart: FC<LineChartProps> = ({
         }}
       />
       <Axis
-        {...{
-          ...horizontalAxis,
-          aScale: xScale,
-          position: horizontalAxis.position || Position.BOTTOM,
-        }}
+        position={horizontalAxis.position || Position.BOTTOM}
+        aScale={xScale}
+        title={horizontalAxis.title}
+        titleAlign={horizontalAxis.titleAlign}
+        tickLength={horizontalAxis.tickLength}
+        tickCount={horizontalAxis.tickCount}
+        tickSize={horizontalAxis.tickSize}
+        tickFormat={horizontalAxis.tickFormat}
       />
       <Axis
-        {...{
-          ...verticalAxis,
-          aScale: yScale,
-          position:
-            verticalAxis.position || (isRTL ? Position.RIGHT : Position.LEFT),
-        }}
+        position={
+          verticalAxis.position || (isRTL ? Position.RIGHT : Position.LEFT)
+        }
+        aScale={yScale}
+        title={verticalAxis.title}
+        titleAlign={verticalAxis.titleAlign}
+        tickLength={verticalAxis.tickLength}
+        tickCount={verticalAxis.tickCount}
+        tickSize={verticalAxis.tickSize}
+        tickFormat={verticalAxis.tickFormat}
       />
     </Chart>
   );

--- a/packages/ez-react/src/recipes/line/LineChart.tsx
+++ b/packages/ez-react/src/recipes/line/LineChart.tsx
@@ -164,7 +164,7 @@ export const LineChart: FC<LineChartProps> = ({
         titleAlign={verticalAxis.titleAlign}
         tickLength={verticalAxis.tickLength}
         tickCount={verticalAxis.tickCount}
-        tickSize={verticalAxis.tickLength}
+        tickSize={verticalAxis.tickSize}
         tickFormat={verticalAxis.tickFormat}
       />
     </Chart>

--- a/packages/ez-react/src/recipes/line/LineErrorMarginChart.tsx
+++ b/packages/ez-react/src/recipes/line/LineErrorMarginChart.tsx
@@ -196,19 +196,26 @@ export const LineErrorMarginChart: FC<LineErrorMarginChartProps> = ({
         }}
       />
       <Axis
-        {...{
-          ...horizontalAxis,
-          aScale: xScale,
-          position: horizontalAxis.position || Position.BOTTOM,
-        }}
+        position={horizontalAxis.position || Position.BOTTOM}
+        aScale={xScale}
+        title={horizontalAxis.title}
+        titleAlign={horizontalAxis.titleAlign}
+        tickLength={horizontalAxis.tickLength}
+        tickCount={horizontalAxis.tickCount}
+        tickSize={horizontalAxis.tickSize}
+        tickFormat={horizontalAxis.tickFormat}
       />
       <Axis
-        {...{
-          ...verticalAxis,
-          aScale: yScale,
-          position:
-            verticalAxis.position || (isRTL ? Position.RIGHT : Position.LEFT),
-        }}
+        position={
+          verticalAxis.position || (isRTL ? Position.RIGHT : Position.LEFT)
+        }
+        aScale={yScale}
+        title={verticalAxis.title}
+        titleAlign={verticalAxis.titleAlign}
+        tickLength={verticalAxis.tickLength}
+        tickCount={verticalAxis.tickCount}
+        tickSize={verticalAxis.tickSize}
+        tickFormat={verticalAxis.tickFormat}
       />
     </Chart>
   );

--- a/packages/ez-react/src/recipes/line/LineErrorMarginChart.tsx
+++ b/packages/ez-react/src/recipes/line/LineErrorMarginChart.tsx
@@ -196,26 +196,19 @@ export const LineErrorMarginChart: FC<LineErrorMarginChartProps> = ({
         }}
       />
       <Axis
-        position={horizontalAxis.position || Position.BOTTOM}
-        aScale={xScale}
-        title={horizontalAxis.title}
-        titleAlign={horizontalAxis.titleAlign}
-        tickLength={horizontalAxis.tickLength}
-        tickCount={horizontalAxis.tickCount}
-        tickSize={horizontalAxis.tickLength}
-        tickFormat={horizontalAxis.tickFormat}
+        {...{
+          ...horizontalAxis,
+          aScale: xScale,
+          position: horizontalAxis.position || Position.BOTTOM,
+        }}
       />
       <Axis
-        position={
-          verticalAxis.position || (isRTL ? Position.RIGHT : Position.LEFT)
-        }
-        aScale={yScale}
-        title={verticalAxis.title}
-        titleAlign={verticalAxis.titleAlign}
-        tickLength={verticalAxis.tickLength}
-        tickCount={verticalAxis.tickCount}
-        tickSize={verticalAxis.tickSize}
-        tickFormat={verticalAxis.tickFormat}
+        {...{
+          ...verticalAxis,
+          aScale: yScale,
+          position:
+            verticalAxis.position || (isRTL ? Position.RIGHT : Position.LEFT),
+        }}
       />
     </Chart>
   );

--- a/packages/ez-react/src/recipes/line/LineErrorMarginChart.tsx
+++ b/packages/ez-react/src/recipes/line/LineErrorMarginChart.tsx
@@ -214,7 +214,7 @@ export const LineErrorMarginChart: FC<LineErrorMarginChartProps> = ({
         titleAlign={verticalAxis.titleAlign}
         tickLength={verticalAxis.tickLength}
         tickCount={verticalAxis.tickCount}
-        tickSize={verticalAxis.tickLength}
+        tickSize={verticalAxis.tickSize}
         tickFormat={verticalAxis.tickFormat}
       />
     </Chart>

--- a/packages/ez-react/src/recipes/line/LineErrorMarginChart.tsx
+++ b/packages/ez-react/src/recipes/line/LineErrorMarginChart.tsx
@@ -196,26 +196,16 @@ export const LineErrorMarginChart: FC<LineErrorMarginChartProps> = ({
         }}
       />
       <Axis
-        position={horizontalAxis.position || Position.BOTTOM}
+        {...horizontalAxis}
         aScale={xScale}
-        title={horizontalAxis.title}
-        titleAlign={horizontalAxis.titleAlign}
-        tickLength={horizontalAxis.tickLength}
-        tickCount={horizontalAxis.tickCount}
-        tickSize={horizontalAxis.tickSize}
-        tickFormat={horizontalAxis.tickFormat}
+        position={horizontalAxis.position || Position.BOTTOM}
       />
       <Axis
+        {...verticalAxis}
+        aScale={yScale}
         position={
           verticalAxis.position || (isRTL ? Position.RIGHT : Position.LEFT)
         }
-        aScale={yScale}
-        title={verticalAxis.title}
-        titleAlign={verticalAxis.titleAlign}
-        tickLength={verticalAxis.tickLength}
-        tickCount={verticalAxis.tickCount}
-        tickSize={verticalAxis.tickSize}
-        tickFormat={verticalAxis.tickFormat}
       />
     </Chart>
   );

--- a/packages/ez-react/src/recipes/scatter/BubbleChart.tsx
+++ b/packages/ez-react/src/recipes/scatter/BubbleChart.tsx
@@ -116,26 +116,16 @@ export const BubbleChart: FC<BubbleChartProps> = ({
       />
       <Bubbles xScale={xScale} yScale={yScale} rScale={rScale} />
       <Axis
-        position={horizontalAxis.position || Position.BOTTOM}
+        {...horizontalAxis}
         aScale={xScale}
-        title={horizontalAxis.title}
-        titleAlign={horizontalAxis.titleAlign}
-        tickLength={horizontalAxis.tickLength}
-        tickCount={horizontalAxis.tickCount}
-        tickSize={horizontalAxis.tickSize}
-        tickFormat={horizontalAxis.tickFormat}
+        position={horizontalAxis.position || Position.BOTTOM}
       />
       <Axis
+        {...verticalAxis}
+        aScale={yScale}
         position={
           verticalAxis.position || (isRTL ? Position.RIGHT : Position.LEFT)
         }
-        aScale={yScale}
-        title={verticalAxis.title}
-        titleAlign={verticalAxis.titleAlign}
-        tickLength={verticalAxis.tickLength}
-        tickCount={verticalAxis.tickCount}
-        tickSize={verticalAxis.tickSize}
-        tickFormat={verticalAxis.tickFormat}
       />
     </Chart>
   );

--- a/packages/ez-react/src/recipes/scatter/BubbleChart.tsx
+++ b/packages/ez-react/src/recipes/scatter/BubbleChart.tsx
@@ -116,26 +116,19 @@ export const BubbleChart: FC<BubbleChartProps> = ({
       />
       <Bubbles xScale={xScale} yScale={yScale} rScale={rScale} />
       <Axis
-        position={horizontalAxis.position || Position.BOTTOM}
-        aScale={xScale}
-        title={horizontalAxis.title}
-        titleAlign={horizontalAxis.titleAlign}
-        tickLength={horizontalAxis.tickLength}
-        tickCount={horizontalAxis.tickCount}
-        tickSize={horizontalAxis.tickLength}
-        tickFormat={horizontalAxis.tickFormat}
+        {...{
+          ...horizontalAxis,
+          aScale: xScale,
+          position: horizontalAxis.position || Position.BOTTOM,
+        }}
       />
       <Axis
-        position={
-          verticalAxis.position || (isRTL ? Position.RIGHT : Position.LEFT)
-        }
-        aScale={yScale}
-        title={verticalAxis.title}
-        titleAlign={verticalAxis.titleAlign}
-        tickLength={verticalAxis.tickLength}
-        tickCount={verticalAxis.tickCount}
-        tickSize={verticalAxis.tickSize}
-        tickFormat={verticalAxis.tickFormat}
+        {...{
+          ...verticalAxis,
+          aScale: yScale,
+          position:
+            verticalAxis.position || (isRTL ? Position.RIGHT : Position.LEFT),
+        }}
       />
     </Chart>
   );

--- a/packages/ez-react/src/recipes/scatter/BubbleChart.tsx
+++ b/packages/ez-react/src/recipes/scatter/BubbleChart.tsx
@@ -116,19 +116,26 @@ export const BubbleChart: FC<BubbleChartProps> = ({
       />
       <Bubbles xScale={xScale} yScale={yScale} rScale={rScale} />
       <Axis
-        {...{
-          ...horizontalAxis,
-          aScale: xScale,
-          position: horizontalAxis.position || Position.BOTTOM,
-        }}
+        position={horizontalAxis.position || Position.BOTTOM}
+        aScale={xScale}
+        title={horizontalAxis.title}
+        titleAlign={horizontalAxis.titleAlign}
+        tickLength={horizontalAxis.tickLength}
+        tickCount={horizontalAxis.tickCount}
+        tickSize={horizontalAxis.tickSize}
+        tickFormat={horizontalAxis.tickFormat}
       />
       <Axis
-        {...{
-          ...verticalAxis,
-          aScale: yScale,
-          position:
-            verticalAxis.position || (isRTL ? Position.RIGHT : Position.LEFT),
-        }}
+        position={
+          verticalAxis.position || (isRTL ? Position.RIGHT : Position.LEFT)
+        }
+        aScale={yScale}
+        title={verticalAxis.title}
+        titleAlign={verticalAxis.titleAlign}
+        tickLength={verticalAxis.tickLength}
+        tickCount={verticalAxis.tickCount}
+        tickSize={verticalAxis.tickSize}
+        tickFormat={verticalAxis.tickFormat}
       />
     </Chart>
   );

--- a/packages/ez-react/src/recipes/scatter/BubbleChart.tsx
+++ b/packages/ez-react/src/recipes/scatter/BubbleChart.tsx
@@ -134,7 +134,7 @@ export const BubbleChart: FC<BubbleChartProps> = ({
         titleAlign={verticalAxis.titleAlign}
         tickLength={verticalAxis.tickLength}
         tickCount={verticalAxis.tickCount}
-        tickSize={verticalAxis.tickLength}
+        tickSize={verticalAxis.tickSize}
         tickFormat={verticalAxis.tickFormat}
       />
     </Chart>

--- a/packages/ez-react/src/recipes/scatter/ScatterChart.tsx
+++ b/packages/ez-react/src/recipes/scatter/ScatterChart.tsx
@@ -106,19 +106,26 @@ export const ScatterChart: FC<ScatterChartProps> = ({
       />
       <Points xScale={xScale} yScale={yScale} r={point.radius} />
       <Axis
-        {...{
-          ...horizontalAxis,
-          aScale: xScale,
-          position: horizontalAxis.position || Position.BOTTOM,
-        }}
+        position={horizontalAxis.position || Position.BOTTOM}
+        aScale={xScale}
+        title={horizontalAxis.title}
+        titleAlign={horizontalAxis.titleAlign}
+        tickLength={horizontalAxis.tickLength}
+        tickCount={horizontalAxis.tickCount}
+        tickSize={horizontalAxis.tickSize}
+        tickFormat={horizontalAxis.tickFormat}
       />
       <Axis
-        {...{
-          ...verticalAxis,
-          aScale: yScale,
-          position:
-            verticalAxis.position || (isRTL ? Position.RIGHT : Position.LEFT),
-        }}
+        position={
+          verticalAxis.position || (isRTL ? Position.RIGHT : Position.LEFT)
+        }
+        aScale={yScale}
+        title={verticalAxis.title}
+        titleAlign={verticalAxis.titleAlign}
+        tickLength={verticalAxis.tickLength}
+        tickCount={verticalAxis.tickCount}
+        tickSize={verticalAxis.tickSize}
+        tickFormat={verticalAxis.tickFormat}
       />
     </Chart>
   );

--- a/packages/ez-react/src/recipes/scatter/ScatterChart.tsx
+++ b/packages/ez-react/src/recipes/scatter/ScatterChart.tsx
@@ -124,7 +124,7 @@ export const ScatterChart: FC<ScatterChartProps> = ({
         titleAlign={verticalAxis.titleAlign}
         tickLength={verticalAxis.tickLength}
         tickCount={verticalAxis.tickCount}
-        tickSize={verticalAxis.tickLength}
+        tickSize={verticalAxis.tickSize}
         tickFormat={verticalAxis.tickFormat}
       />
     </Chart>

--- a/packages/ez-react/src/recipes/scatter/ScatterChart.tsx
+++ b/packages/ez-react/src/recipes/scatter/ScatterChart.tsx
@@ -106,26 +106,19 @@ export const ScatterChart: FC<ScatterChartProps> = ({
       />
       <Points xScale={xScale} yScale={yScale} r={point.radius} />
       <Axis
-        position={horizontalAxis.position || Position.BOTTOM}
-        aScale={xScale}
-        title={horizontalAxis.title}
-        titleAlign={horizontalAxis.titleAlign}
-        tickLength={horizontalAxis.tickLength}
-        tickCount={horizontalAxis.tickCount}
-        tickSize={horizontalAxis.tickLength}
-        tickFormat={horizontalAxis.tickFormat}
+        {...{
+          ...horizontalAxis,
+          aScale: xScale,
+          position: horizontalAxis.position || Position.BOTTOM,
+        }}
       />
       <Axis
-        position={
-          verticalAxis.position || (isRTL ? Position.RIGHT : Position.LEFT)
-        }
-        aScale={yScale}
-        title={verticalAxis.title}
-        titleAlign={verticalAxis.titleAlign}
-        tickLength={verticalAxis.tickLength}
-        tickCount={verticalAxis.tickCount}
-        tickSize={verticalAxis.tickSize}
-        tickFormat={verticalAxis.tickFormat}
+        {...{
+          ...verticalAxis,
+          aScale: yScale,
+          position:
+            verticalAxis.position || (isRTL ? Position.RIGHT : Position.LEFT),
+        }}
       />
     </Chart>
   );

--- a/packages/ez-react/src/recipes/scatter/ScatterChart.tsx
+++ b/packages/ez-react/src/recipes/scatter/ScatterChart.tsx
@@ -106,26 +106,16 @@ export const ScatterChart: FC<ScatterChartProps> = ({
       />
       <Points xScale={xScale} yScale={yScale} r={point.radius} />
       <Axis
-        position={horizontalAxis.position || Position.BOTTOM}
+        {...horizontalAxis}
         aScale={xScale}
-        title={horizontalAxis.title}
-        titleAlign={horizontalAxis.titleAlign}
-        tickLength={horizontalAxis.tickLength}
-        tickCount={horizontalAxis.tickCount}
-        tickSize={horizontalAxis.tickSize}
-        tickFormat={horizontalAxis.tickFormat}
+        position={horizontalAxis.position || Position.BOTTOM}
       />
       <Axis
+        {...verticalAxis}
+        aScale={yScale}
         position={
           verticalAxis.position || (isRTL ? Position.RIGHT : Position.LEFT)
         }
-        aScale={yScale}
-        title={verticalAxis.title}
-        titleAlign={verticalAxis.titleAlign}
-        tickLength={verticalAxis.tickLength}
-        tickCount={verticalAxis.tickCount}
-        tickSize={verticalAxis.tickSize}
-        tickFormat={verticalAxis.tickFormat}
       />
     </Chart>
   );

--- a/packages/ez-vue/src/recipes/area/AreaChart.tsx
+++ b/packages/ez-vue/src/recipes/area/AreaChart.tsx
@@ -259,27 +259,19 @@ export default class AreaChart extends Vue {
           }}
         />
         <Axis
-          position={horizontalAxis.position || Position.BOTTOM}
-          aScale={xScale}
-          title={horizontalAxis.title}
-          titleAlign={horizontalAxis.titleAlign}
-          tickLength={horizontalAxis.tickLength}
-          tickCount={horizontalAxis.tickCount}
-          tickSize={horizontalAxis.tickSize}
-          tickFormat={horizontalAxis.tickFormat}
+          {...{
+            ...horizontalAxis,
+            aScale: xScale,
+            position: horizontalAxis.position || Position.BOTTOM,
+          }}
         />
         <Axis
-          position={
-            verticalAxis.position
-            || (isRTL ? Position.RIGHT : Position.LEFT)
-          }
-          aScale={yScale}
-          title={verticalAxis.title}
-          titleAlign={verticalAxis.titleAlign}
-          tickLength={verticalAxis.tickLength}
-          tickCount={verticalAxis.tickCount}
-          tickSize={verticalAxis.tickSize}
-          tickFormat={verticalAxis.tickFormat}
+          {...{
+            ...verticalAxis,
+            aScale: yScale,
+            position:
+              verticalAxis.position || (isRTL ? Position.RIGHT : Position.LEFT),
+          }}
         />
       </Chart>
     );

--- a/packages/ez-vue/src/recipes/area/AreaChart.tsx
+++ b/packages/ez-vue/src/recipes/area/AreaChart.tsx
@@ -243,8 +243,8 @@ export default class AreaChart extends Vue {
                     stroke={area.stroke}
                     strokeWidth={area.strokeWidth}
                   />
-                  {!marker.hidden &&
-                    scaledData.map((pointDatum) => (
+                  {!marker.hidden
+                    && scaledData.map((pointDatum) => (
                       <Point
                         key={pointDatum.id}
                         shapeDatum={pointDatum}

--- a/packages/ez-vue/src/recipes/area/AreaChart.tsx
+++ b/packages/ez-vue/src/recipes/area/AreaChart.tsx
@@ -265,7 +265,7 @@ export default class AreaChart extends Vue {
           titleAlign={horizontalAxis.titleAlign}
           tickLength={horizontalAxis.tickLength}
           tickCount={horizontalAxis.tickCount}
-          tickSize={horizontalAxis.tickLength}
+          tickSize={horizontalAxis.tickSize}
           tickFormat={horizontalAxis.tickFormat}
         />
         <Axis
@@ -278,7 +278,7 @@ export default class AreaChart extends Vue {
           titleAlign={verticalAxis.titleAlign}
           tickLength={verticalAxis.tickLength}
           tickCount={verticalAxis.tickCount}
-          tickSize={verticalAxis.tickLength}
+          tickSize={verticalAxis.tickSize}
           tickFormat={verticalAxis.tickFormat}
         />
       </Chart>

--- a/packages/ez-vue/src/recipes/area/AreaChart.tsx
+++ b/packages/ez-vue/src/recipes/area/AreaChart.tsx
@@ -259,19 +259,27 @@ export default class AreaChart extends Vue {
           }}
         />
         <Axis
-          {...{
-            ...horizontalAxis,
-            aScale: xScale,
-            position: horizontalAxis.position || Position.BOTTOM,
-          }}
+          position={horizontalAxis.position || Position.BOTTOM}
+          aScale={xScale}
+          title={horizontalAxis.title}
+          titleAlign={horizontalAxis.titleAlign}
+          tickLength={horizontalAxis.tickLength}
+          tickCount={horizontalAxis.tickCount}
+          tickSize={horizontalAxis.tickSize}
+          tickFormat={horizontalAxis.tickFormat}
         />
         <Axis
-          {...{
-            ...verticalAxis,
-            aScale: yScale,
-            position:
-              verticalAxis.position || (isRTL ? Position.RIGHT : Position.LEFT),
-          }}
+          position={
+            verticalAxis.position
+            || (isRTL ? Position.RIGHT : Position.LEFT)
+          }
+          aScale={yScale}
+          title={verticalAxis.title}
+          titleAlign={verticalAxis.titleAlign}
+          tickLength={verticalAxis.tickLength}
+          tickCount={verticalAxis.tickCount}
+          tickSize={verticalAxis.tickSize}
+          tickFormat={verticalAxis.tickFormat}
         />
       </Chart>
     );

--- a/packages/ez-vue/src/recipes/area/AreaChart.tsx
+++ b/packages/ez-vue/src/recipes/area/AreaChart.tsx
@@ -259,16 +259,18 @@ export default class AreaChart extends Vue {
           }}
         />
         <Axis
-          {...horizontalAxis}
-          aScale={xScale}
-          position={horizontalAxis.position || Position.BOTTOM}
+          props={{
+            ...horizontalAxis,
+            aScale: xScale,
+            position: horizontalAxis.position || Position.BOTTOM,
+          }}
         />
         <Axis
-          {...verticalAxis}
-          aScale={yScale}
-          position={
-            verticalAxis.position || (isRTL ? Position.RIGHT : Position.LEFT)
-          }
+          props={{
+            ...verticalAxis,
+            aScale: yScale,
+            position: verticalAxis.position || (isRTL ? Position.RIGHT : Position.LEFT),
+          }}
         />
       </Chart>
     );

--- a/packages/ez-vue/src/recipes/area/AreaChart.tsx
+++ b/packages/ez-vue/src/recipes/area/AreaChart.tsx
@@ -243,8 +243,8 @@ export default class AreaChart extends Vue {
                     stroke={area.stroke}
                     strokeWidth={area.strokeWidth}
                   />
-                  {!marker.hidden
-                    && scaledData.map((pointDatum) => (
+                  {!marker.hidden &&
+                    scaledData.map((pointDatum) => (
                       <Point
                         key={pointDatum.id}
                         shapeDatum={pointDatum}
@@ -259,27 +259,16 @@ export default class AreaChart extends Vue {
           }}
         />
         <Axis
-          position={horizontalAxis.position || Position.BOTTOM}
+          {...horizontalAxis}
           aScale={xScale}
-          title={horizontalAxis.title}
-          titleAlign={horizontalAxis.titleAlign}
-          tickLength={horizontalAxis.tickLength}
-          tickCount={horizontalAxis.tickCount}
-          tickSize={horizontalAxis.tickSize}
-          tickFormat={horizontalAxis.tickFormat}
+          position={horizontalAxis.position || Position.BOTTOM}
         />
         <Axis
-          position={
-            verticalAxis.position
-            || (isRTL ? Position.RIGHT : Position.LEFT)
-          }
+          {...verticalAxis}
           aScale={yScale}
-          title={verticalAxis.title}
-          titleAlign={verticalAxis.titleAlign}
-          tickLength={verticalAxis.tickLength}
-          tickCount={verticalAxis.tickCount}
-          tickSize={verticalAxis.tickSize}
-          tickFormat={verticalAxis.tickFormat}
+          position={
+            verticalAxis.position || (isRTL ? Position.RIGHT : Position.LEFT)
+          }
         />
       </Chart>
     );

--- a/packages/ez-vue/src/recipes/bar/BarChart.tsx
+++ b/packages/ez-vue/src/recipes/bar/BarChart.tsx
@@ -177,14 +177,19 @@ export default class BarChart extends Vue {
         />
         <Bars xScale={xScale} yScale={yScale} />
         <Axis
-          {...xAxis}
-          aScale={xScale}
-          position={xAxis.position || Position.BOTTOM}
+          props={{
+            ...xAxis,
+            aScale: xScale,
+            position: xAxis.position || Position.BOTTOM,
+          }}
         />
         <Axis
-          {...yAxis}
-          aScale={yScale}
-          position={yAxis.position || (isRTL ? Position.RIGHT : Position.LEFT)}
+          props={{
+            ...yAxis,
+            aScale: yScale,
+            position:
+              yAxis.position || (isRTL ? Position.RIGHT : Position.LEFT),
+          }}
         />
       </Chart>
     );

--- a/packages/ez-vue/src/recipes/bar/BarChart.tsx
+++ b/packages/ez-vue/src/recipes/bar/BarChart.tsx
@@ -152,9 +152,7 @@ export default class BarChart extends Vue {
       dimensions,
     } = this;
 
-    const defaultLegend = (props: {}) => (
-      <Legend ref="legend" props={props} />
-    );
+    const defaultLegend = (props: {}) => <Legend ref="legend" props={props} />;
     const scopedSlots = {
       Legend: $scopedSlots.Legend ? $scopedSlots.Legend : defaultLegend,
       Tooltip: $scopedSlots.Tooltip,
@@ -179,26 +177,14 @@ export default class BarChart extends Vue {
         />
         <Bars xScale={xScale} yScale={yScale} />
         <Axis
+          {...xAxis}
           aScale={xScale}
           position={xAxis.position || Position.BOTTOM}
-          title={xAxis.title}
-          titleAlign={xAxis.titleAlign}
-          tickCount={xAxis.tickCount}
-          tickSize={xAxis.tickSize}
-          tickLength={xAxis.tickLength}
-          tickFormat={xAxis.tickFormat}
         />
         <Axis
+          {...yAxis}
           aScale={yScale}
-          position={
-            yAxis.position || (isRTL ? Position.RIGHT : Position.LEFT)
-          }
-          title={yAxis.title}
-          titleAlign={yAxis.titleAlign}
-          tickCount={yAxis.tickCount}
-          tickSize={yAxis.tickSize}
-          tickLength={yAxis.tickLength}
-          tickFormat={yAxis.tickFormat}
+          position={yAxis.position || (isRTL ? Position.RIGHT : Position.LEFT)}
         />
       </Chart>
     );

--- a/packages/ez-vue/src/recipes/column/ColumnChart.tsx
+++ b/packages/ez-vue/src/recipes/column/ColumnChart.tsx
@@ -175,26 +175,14 @@ export default class ColumnChart extends Vue {
         />
         <Bars xScale={xScale} yScale={yScale} />
         <Axis
+          {...xAxis}
           aScale={xScale}
           position={xAxis.position || Position.BOTTOM}
-          title={xAxis.title}
-          titleAlign={xAxis.titleAlign}
-          tickCount={xAxis.tickCount}
-          tickSize={xAxis.tickSize}
-          tickLength={xAxis.tickLength}
-          tickFormat={xAxis.tickFormat}
         />
         <Axis
+          {...yAxis}
           aScale={yScale}
-          position={
-            yAxis.position || (isRTL ? Position.RIGHT : Position.LEFT)
-          }
-          title={yAxis.title}
-          titleAlign={yAxis.titleAlign}
-          tickCount={yAxis.tickCount}
-          tickSize={yAxis.tickSize}
-          tickLength={yAxis.tickLength}
-          tickFormat={yAxis.tickFormat}
+          position={yAxis.position || (isRTL ? Position.RIGHT : Position.LEFT)}
         />
       </Chart>
     );

--- a/packages/ez-vue/src/recipes/column/ColumnChart.tsx
+++ b/packages/ez-vue/src/recipes/column/ColumnChart.tsx
@@ -175,14 +175,19 @@ export default class ColumnChart extends Vue {
         />
         <Bars xScale={xScale} yScale={yScale} />
         <Axis
-          {...xAxis}
-          aScale={xScale}
-          position={xAxis.position || Position.BOTTOM}
+          props={{
+            ...xAxis,
+            aScale: xScale,
+            position: xAxis.position || Position.BOTTOM,
+          }}
         />
         <Axis
-          {...yAxis}
-          aScale={yScale}
-          position={yAxis.position || (isRTL ? Position.RIGHT : Position.LEFT)}
+          props={{
+            ...yAxis,
+            aScale: yScale,
+            position:
+              yAxis.position || (isRTL ? Position.RIGHT : Position.LEFT),
+          }}
         />
       </Chart>
     );

--- a/packages/ez-vue/src/recipes/column/LineColumnChart.tsx
+++ b/packages/ez-vue/src/recipes/column/LineColumnChart.tsx
@@ -270,9 +270,11 @@ export default class LineColumnChart extends Vue {
           }}
         />
         <Axis
-          {...xAxis}
-          aScale={xColumnScale}
-          position={xAxis.position || Position.BOTTOM}
+          props={{
+            ...xAxis,
+            aScale: xColumnScale,
+            position: xAxis.position || Position.BOTTOM,
+          }}
         />
         <Axis
           props={{

--- a/packages/ez-vue/src/recipes/column/LineColumnChart.tsx
+++ b/packages/ez-vue/src/recipes/column/LineColumnChart.tsx
@@ -275,16 +275,20 @@ export default class LineColumnChart extends Vue {
           position={xAxis.position || Position.BOTTOM}
         />
         <Axis
-          {...yAxis}
-          aScale={yColumnScale}
-          position={yAxis.position || (isRTL ? Position.RIGHT : Position.LEFT)}
+          props={{
+            ...yAxis,
+            aScale: yColumnScale,
+            position:
+              yAxis.position || (isRTL ? Position.RIGHT : Position.LEFT),
+          }}
         />
         <Axis
-          {...yLineAxis}
-          aScale={yLineScale}
-          position={
-            yLineAxis.position || (isRTL ? Position.LEFT : Position.RIGHT)
-          }
+          props={{
+            ...yLineAxis,
+            aScale: yLineScale,
+            position:
+              yLineAxis.position || (isRTL ? Position.LEFT : Position.RIGHT),
+          }}
         />
       </Chart>
     );

--- a/packages/ez-vue/src/recipes/column/LineColumnChart.tsx
+++ b/packages/ez-vue/src/recipes/column/LineColumnChart.tsx
@@ -240,10 +240,7 @@ export default class LineColumnChart extends Vue {
           xScale={xColumnScale}
           yScale={yColumnScale}
         />
-        <Bars
-          xScale={xColumnScale}
-          yScale={yColumnScale}
-        />
+        <Bars xScale={xColumnScale} yScale={yColumnScale} />
         <Points
           xScale={xLineScale}
           yScale={yLineScale}
@@ -257,8 +254,8 @@ export default class LineColumnChart extends Vue {
                   stroke={line.stroke}
                   strokeWidth={line.strokeWidth}
                 />
-                {!marker.hidden
-                  && scaledData.map((pointDatum) => (
+                {!marker.hidden &&
+                  scaledData.map((pointDatum) => (
                     <Point
                       key={pointDatum.id}
                       shapeDatum={pointDatum}
@@ -273,38 +270,21 @@ export default class LineColumnChart extends Vue {
           }}
         />
         <Axis
+          {...xAxis}
           aScale={xColumnScale}
           position={xAxis.position || Position.BOTTOM}
-          title={xAxis.title}
-          titleAlign={xAxis.titleAlign}
-          tickCount={xAxis.tickCount}
-          tickSize={xAxis.tickSize}
-          tickLength={xAxis.tickLength}
-          tickFormat={xAxis.tickFormat}
         />
         <Axis
+          {...yAxis}
           aScale={yColumnScale}
-          position={
-            yAxis.position || (isRTL ? Position.RIGHT : Position.LEFT)
-          }
-          title={yAxis.title}
-          titleAlign={yAxis.titleAlign}
-          tickCount={yAxis.tickCount}
-          tickSize={yAxis.tickSize}
-          tickLength={yAxis.tickLength}
-          tickFormat={yAxis.tickFormat}
+          position={yAxis.position || (isRTL ? Position.RIGHT : Position.LEFT)}
         />
         <Axis
+          {...yLineAxis}
           aScale={yLineScale}
           position={
             yLineAxis.position || (isRTL ? Position.LEFT : Position.RIGHT)
           }
-          title={yLineAxis.title}
-          titleAlign={yLineAxis.titleAlign}
-          tickCount={yLineAxis.tickCount}
-          tickSize={yLineAxis.tickSize}
-          tickLength={yLineAxis.tickLength}
-          tickFormat={yLineAxis.tickFormat}
         />
       </Chart>
     );

--- a/packages/ez-vue/src/recipes/column/LineColumnChart.tsx
+++ b/packages/ez-vue/src/recipes/column/LineColumnChart.tsx
@@ -254,8 +254,8 @@ export default class LineColumnChart extends Vue {
                   stroke={line.stroke}
                   strokeWidth={line.strokeWidth}
                 />
-                {!marker.hidden &&
-                  scaledData.map((pointDatum) => (
+                {!marker.hidden
+                  && scaledData.map((pointDatum) => (
                     <Point
                       key={pointDatum.id}
                       shapeDatum={pointDatum}

--- a/packages/ez-vue/src/recipes/line/LineChart.tsx
+++ b/packages/ez-vue/src/recipes/line/LineChart.tsx
@@ -236,19 +236,27 @@ export default class LineChart extends Vue {
           }}
         />
         <Axis
-          {...{
-            ...horizontalAxis,
-            aScale: xScale,
-            position: horizontalAxis.position || Position.BOTTOM,
-          }}
+          position={horizontalAxis.position || Position.BOTTOM}
+          aScale={xScale}
+          title={horizontalAxis.title}
+          titleAlign={horizontalAxis.titleAlign}
+          tickLength={horizontalAxis.tickLength}
+          tickCount={horizontalAxis.tickCount}
+          tickSize={horizontalAxis.tickSize}
+          tickFormat={horizontalAxis.tickFormat}
         />
         <Axis
-            {...{
-              ...verticalAxis,
-              aScale: yScale,
-              position:
-                verticalAxis.position || (isRTL ? Position.RIGHT : Position.LEFT),
-            }}
+          position={
+            verticalAxis.position
+            || (isRTL ? Position.RIGHT : Position.LEFT)
+          }
+          aScale={yScale}
+          title={verticalAxis.title}
+          titleAlign={verticalAxis.titleAlign}
+          tickLength={verticalAxis.tickLength}
+          tickCount={verticalAxis.tickCount}
+          tickSize={verticalAxis.tickSize}
+          tickFormat={verticalAxis.tickFormat}
         />
       </Chart>
     );

--- a/packages/ez-vue/src/recipes/line/LineChart.tsx
+++ b/packages/ez-vue/src/recipes/line/LineChart.tsx
@@ -236,27 +236,19 @@ export default class LineChart extends Vue {
           }}
         />
         <Axis
-          position={horizontalAxis.position || Position.BOTTOM}
-          aScale={xScale}
-          title={horizontalAxis.title}
-          titleAlign={horizontalAxis.titleAlign}
-          tickLength={horizontalAxis.tickLength}
-          tickCount={horizontalAxis.tickCount}
-          tickSize={horizontalAxis.tickLength}
-          tickFormat={horizontalAxis.tickFormat}
+          {...{
+            ...horizontalAxis,
+            aScale: xScale,
+            position: horizontalAxis.position || Position.BOTTOM,
+          }}
         />
         <Axis
-          position={
-            verticalAxis.position
-            || (isRTL ? Position.RIGHT : Position.LEFT)
-          }
-          aScale={yScale}
-          title={verticalAxis.title}
-          titleAlign={verticalAxis.titleAlign}
-          tickLength={verticalAxis.tickLength}
-          tickCount={verticalAxis.tickCount}
-          tickSize={verticalAxis.tickSize}
-          tickFormat={verticalAxis.tickFormat}
+            {...{
+              ...verticalAxis,
+              aScale: yScale,
+              position:
+                verticalAxis.position || (isRTL ? Position.RIGHT : Position.LEFT),
+            }}
         />
       </Chart>
     );

--- a/packages/ez-vue/src/recipes/line/LineChart.tsx
+++ b/packages/ez-vue/src/recipes/line/LineChart.tsx
@@ -236,16 +236,19 @@ export default class LineChart extends Vue {
           }}
         />
         <Axis
-          {...horizontalAxis}
-          aScale={xScale}
-          position={horizontalAxis.position || Position.BOTTOM}
+          props={{
+            ...horizontalAxis,
+            aScale: xScale,
+            position: horizontalAxis.position || Position.BOTTOM,
+          }}
         />
         <Axis
-          {...verticalAxis}
-          aScale={yScale}
-          position={
-            verticalAxis.position || (isRTL ? Position.RIGHT : Position.LEFT)
-          }
+          props={{
+            ...verticalAxis,
+            aScale: yScale,
+            position:
+              verticalAxis.position || (isRTL ? Position.RIGHT : Position.LEFT),
+          }}
         />
       </Chart>
     );

--- a/packages/ez-vue/src/recipes/line/LineChart.tsx
+++ b/packages/ez-vue/src/recipes/line/LineChart.tsx
@@ -221,8 +221,8 @@ export default class LineChart extends Vue {
                   stroke={line.stroke}
                   strokeWidth={line.strokeWidth}
                 />
-                {!marker.hidden
-                  && scaledData.map((pointDatum) => (
+                {!marker.hidden &&
+                  scaledData.map((pointDatum) => (
                     <Point
                       key={pointDatum.id}
                       shapeDatum={pointDatum}
@@ -236,27 +236,16 @@ export default class LineChart extends Vue {
           }}
         />
         <Axis
-          position={horizontalAxis.position || Position.BOTTOM}
+          {...horizontalAxis}
           aScale={xScale}
-          title={horizontalAxis.title}
-          titleAlign={horizontalAxis.titleAlign}
-          tickLength={horizontalAxis.tickLength}
-          tickCount={horizontalAxis.tickCount}
-          tickSize={horizontalAxis.tickSize}
-          tickFormat={horizontalAxis.tickFormat}
+          position={horizontalAxis.position || Position.BOTTOM}
         />
         <Axis
-          position={
-            verticalAxis.position
-            || (isRTL ? Position.RIGHT : Position.LEFT)
-          }
+          {...verticalAxis}
           aScale={yScale}
-          title={verticalAxis.title}
-          titleAlign={verticalAxis.titleAlign}
-          tickLength={verticalAxis.tickLength}
-          tickCount={verticalAxis.tickCount}
-          tickSize={verticalAxis.tickSize}
-          tickFormat={verticalAxis.tickFormat}
+          position={
+            verticalAxis.position || (isRTL ? Position.RIGHT : Position.LEFT)
+          }
         />
       </Chart>
     );

--- a/packages/ez-vue/src/recipes/line/LineChart.tsx
+++ b/packages/ez-vue/src/recipes/line/LineChart.tsx
@@ -255,7 +255,7 @@ export default class LineChart extends Vue {
           titleAlign={verticalAxis.titleAlign}
           tickLength={verticalAxis.tickLength}
           tickCount={verticalAxis.tickCount}
-          tickSize={verticalAxis.tickLength}
+          tickSize={verticalAxis.tickSize}
           tickFormat={verticalAxis.tickFormat}
         />
       </Chart>

--- a/packages/ez-vue/src/recipes/line/LineChart.tsx
+++ b/packages/ez-vue/src/recipes/line/LineChart.tsx
@@ -221,8 +221,8 @@ export default class LineChart extends Vue {
                   stroke={line.stroke}
                   strokeWidth={line.strokeWidth}
                 />
-                {!marker.hidden &&
-                  scaledData.map((pointDatum) => (
+                {!marker.hidden
+                  && scaledData.map((pointDatum) => (
                     <Point
                       key={pointDatum.id}
                       shapeDatum={pointDatum}

--- a/packages/ez-vue/src/recipes/line/LineErrorMarginChart.tsx
+++ b/packages/ez-vue/src/recipes/line/LineErrorMarginChart.tsx
@@ -260,12 +260,12 @@ export default class LineErrorMarginChart extends Vue {
                 return {
                   x: d.x,
                   y0: yScale.scale(
-                    (datum[verticalAxis.domainKey] as number) *
-                      (1 - Number(datum[errorMargins.negative])),
+                    (datum[verticalAxis.domainKey] as number)
+                      * (1 - Number(datum[errorMargins.negative])),
                   ),
                   y1: yScale.scale(
-                    (datum[verticalAxis.domainKey] as number) *
-                      (1 + Number(datum[errorMargins.positive])),
+                    (datum[verticalAxis.domainKey] as number)
+                      * (1 + Number(datum[errorMargins.positive])),
                   ),
                 };
               });

--- a/packages/ez-vue/src/recipes/line/LineErrorMarginChart.tsx
+++ b/packages/ez-vue/src/recipes/line/LineErrorMarginChart.tsx
@@ -260,12 +260,12 @@ export default class LineErrorMarginChart extends Vue {
                 return {
                   x: d.x,
                   y0: yScale.scale(
-                    (datum[verticalAxis.domainKey] as number)
-                      * (1 - Number(datum[errorMargins.negative])),
+                    (datum[verticalAxis.domainKey] as number) *
+                      (1 - Number(datum[errorMargins.negative])),
                   ),
                   y1: yScale.scale(
-                    (datum[verticalAxis.domainKey] as number)
-                      * (1 + Number(datum[errorMargins.positive])),
+                    (datum[verticalAxis.domainKey] as number) *
+                      (1 + Number(datum[errorMargins.positive])),
                   ),
                 };
               });
@@ -285,8 +285,8 @@ export default class LineErrorMarginChart extends Vue {
                     stroke={line.stroke}
                     strokeWidth={line.strokeWidth}
                   />
-                  {!marker.hidden
-                    && scaledData.map((pointDatum) => (
+                  {!marker.hidden &&
+                    scaledData.map((pointDatum) => (
                       <Point
                         key={pointDatum.id}
                         shapeDatum={pointDatum}
@@ -301,27 +301,16 @@ export default class LineErrorMarginChart extends Vue {
           }}
         />
         <Axis
-          position={horizontalAxis.position || Position.BOTTOM}
+          {...horizontalAxis}
           aScale={xScale}
-          title={horizontalAxis.title}
-          titleAlign={horizontalAxis.titleAlign}
-          tickLength={horizontalAxis.tickLength}
-          tickCount={horizontalAxis.tickCount}
-          tickSize={horizontalAxis.tickSize}
-          tickFormat={horizontalAxis.tickFormat}
+          position={horizontalAxis.position || Position.BOTTOM}
         />
         <Axis
-          position={
-            verticalAxis.position
-            || (isRTL ? Position.RIGHT : Position.LEFT)
-          }
+          {...verticalAxis}
           aScale={yScale}
-          title={verticalAxis.title}
-          titleAlign={verticalAxis.titleAlign}
-          tickLength={verticalAxis.tickLength}
-          tickCount={verticalAxis.tickCount}
-          tickSize={verticalAxis.tickSize}
-          tickFormat={verticalAxis.tickFormat}
+          position={
+            verticalAxis.position || (isRTL ? Position.RIGHT : Position.LEFT)
+          }
         />
       </Chart>
     );

--- a/packages/ez-vue/src/recipes/line/LineErrorMarginChart.tsx
+++ b/packages/ez-vue/src/recipes/line/LineErrorMarginChart.tsx
@@ -301,27 +301,19 @@ export default class LineErrorMarginChart extends Vue {
           }}
         />
         <Axis
-          position={horizontalAxis.position || Position.BOTTOM}
-          aScale={xScale}
-          title={horizontalAxis.title}
-          titleAlign={horizontalAxis.titleAlign}
-          tickLength={horizontalAxis.tickLength}
-          tickCount={horizontalAxis.tickCount}
-          tickSize={horizontalAxis.tickLength}
-          tickFormat={horizontalAxis.tickFormat}
+          {...{
+            ...horizontalAxis,
+            aScale: xScale,
+            position: horizontalAxis.position || Position.BOTTOM,
+          }}
         />
         <Axis
-          position={
-            verticalAxis.position
-            || (isRTL ? Position.RIGHT : Position.LEFT)
-          }
-          aScale={yScale}
-          title={verticalAxis.title}
-          titleAlign={verticalAxis.titleAlign}
-          tickLength={verticalAxis.tickLength}
-          tickCount={verticalAxis.tickCount}
-          tickSize={verticalAxis.tickSize}
-          tickFormat={verticalAxis.tickFormat}
+          {...{
+            ...verticalAxis,
+            aScale: yScale,
+            position:
+              verticalAxis.position || (isRTL ? Position.RIGHT : Position.LEFT),
+          }}
         />
       </Chart>
     );

--- a/packages/ez-vue/src/recipes/line/LineErrorMarginChart.tsx
+++ b/packages/ez-vue/src/recipes/line/LineErrorMarginChart.tsx
@@ -285,8 +285,8 @@ export default class LineErrorMarginChart extends Vue {
                     stroke={line.stroke}
                     strokeWidth={line.strokeWidth}
                   />
-                  {!marker.hidden &&
-                    scaledData.map((pointDatum) => (
+                  {!marker.hidden
+                    && scaledData.map((pointDatum) => (
                       <Point
                         key={pointDatum.id}
                         shapeDatum={pointDatum}

--- a/packages/ez-vue/src/recipes/line/LineErrorMarginChart.tsx
+++ b/packages/ez-vue/src/recipes/line/LineErrorMarginChart.tsx
@@ -301,19 +301,27 @@ export default class LineErrorMarginChart extends Vue {
           }}
         />
         <Axis
-          {...{
-            ...horizontalAxis,
-            aScale: xScale,
-            position: horizontalAxis.position || Position.BOTTOM,
-          }}
+          position={horizontalAxis.position || Position.BOTTOM}
+          aScale={xScale}
+          title={horizontalAxis.title}
+          titleAlign={horizontalAxis.titleAlign}
+          tickLength={horizontalAxis.tickLength}
+          tickCount={horizontalAxis.tickCount}
+          tickSize={horizontalAxis.tickSize}
+          tickFormat={horizontalAxis.tickFormat}
         />
         <Axis
-          {...{
-            ...verticalAxis,
-            aScale: yScale,
-            position:
-              verticalAxis.position || (isRTL ? Position.RIGHT : Position.LEFT),
-          }}
+          position={
+            verticalAxis.position
+            || (isRTL ? Position.RIGHT : Position.LEFT)
+          }
+          aScale={yScale}
+          title={verticalAxis.title}
+          titleAlign={verticalAxis.titleAlign}
+          tickLength={verticalAxis.tickLength}
+          tickCount={verticalAxis.tickCount}
+          tickSize={verticalAxis.tickSize}
+          tickFormat={verticalAxis.tickFormat}
         />
       </Chart>
     );

--- a/packages/ez-vue/src/recipes/line/LineErrorMarginChart.tsx
+++ b/packages/ez-vue/src/recipes/line/LineErrorMarginChart.tsx
@@ -320,7 +320,7 @@ export default class LineErrorMarginChart extends Vue {
           titleAlign={verticalAxis.titleAlign}
           tickLength={verticalAxis.tickLength}
           tickCount={verticalAxis.tickCount}
-          tickSize={verticalAxis.tickLength}
+          tickSize={verticalAxis.tickSize}
           tickFormat={verticalAxis.tickFormat}
         />
       </Chart>

--- a/packages/ez-vue/src/recipes/line/LineErrorMarginChart.tsx
+++ b/packages/ez-vue/src/recipes/line/LineErrorMarginChart.tsx
@@ -301,16 +301,19 @@ export default class LineErrorMarginChart extends Vue {
           }}
         />
         <Axis
-          {...horizontalAxis}
-          aScale={xScale}
-          position={horizontalAxis.position || Position.BOTTOM}
+          props={{
+            ...horizontalAxis,
+            aScale: xScale,
+            position: horizontalAxis.position || Position.BOTTOM,
+          }}
         />
         <Axis
-          {...verticalAxis}
-          aScale={yScale}
-          position={
-            verticalAxis.position || (isRTL ? Position.RIGHT : Position.LEFT)
-          }
+          props={{
+            ...verticalAxis,
+            aScale: yScale,
+            position:
+              verticalAxis.position || (isRTL ? Position.RIGHT : Position.LEFT),
+          }}
         />
       </Chart>
     );

--- a/packages/ez-vue/src/recipes/scatter/BubbleChart.tsx
+++ b/packages/ez-vue/src/recipes/scatter/BubbleChart.tsx
@@ -132,9 +132,12 @@ export default class BubbleChart extends Vue {
   private readonly isRTL!: boolean;
 
   @Prop({
-    type: Function as PropType<(dimensions: Dimensions) => void>,
+    type: Function as PropType<
+      (dimensions: Dimensions) => void
+    >,
     required: false,
   })
+
   get horizontalAxis() {
     return this.swapAxis ? this.yAxis : this.xAxis;
   }
@@ -203,17 +206,25 @@ export default class BubbleChart extends Vue {
           xScale={xScale}
           yScale={yScale}
         />
-        <Bubbles xScale={xScale} yScale={yScale} rScale={rScale} />
+        <Bubbles
+          xScale={xScale}
+          yScale={yScale}
+          rScale={rScale}
+        />
         <Axis
-          {...{
-            ...horizontalAxis,
-            aScale: xScale,
-            position: horizontalAxis.position || Position.BOTTOM,
-          }}
+          position={horizontalAxis.position || Position.BOTTOM}
+          aScale={xScale}
+          title={horizontalAxis.title}
+          titleAlign={horizontalAxis.titleAlign}
+          tickLength={horizontalAxis.tickLength}
+          tickCount={horizontalAxis.tickCount}
+          tickSize={horizontalAxis.tickSize}
+          tickFormat={horizontalAxis.tickFormat}
         />
         <Axis
           position={
-            verticalAxis.position || (isRTL ? Position.RIGHT : Position.LEFT)
+            verticalAxis.position
+            || (isRTL ? Position.RIGHT : Position.LEFT)
           }
           aScale={yScale}
           title={verticalAxis.title}

--- a/packages/ez-vue/src/recipes/scatter/BubbleChart.tsx
+++ b/packages/ez-vue/src/recipes/scatter/BubbleChart.tsx
@@ -132,12 +132,9 @@ export default class BubbleChart extends Vue {
   private readonly isRTL!: boolean;
 
   @Prop({
-    type: Function as PropType<
-      (dimensions: Dimensions) => void
-    >,
+    type: Function as PropType<(dimensions: Dimensions) => void>,
     required: false,
   })
-
   get horizontalAxis() {
     return this.swapAxis ? this.yAxis : this.xAxis;
   }
@@ -206,33 +203,18 @@ export default class BubbleChart extends Vue {
           xScale={xScale}
           yScale={yScale}
         />
-        <Bubbles
-          xScale={xScale}
-          yScale={yScale}
-          rScale={rScale}
-        />
+        <Bubbles xScale={xScale} yScale={yScale} rScale={rScale} />
         <Axis
-          position={horizontalAxis.position || Position.BOTTOM}
+          {...horizontalAxis}
           aScale={xScale}
-          title={horizontalAxis.title}
-          titleAlign={horizontalAxis.titleAlign}
-          tickLength={horizontalAxis.tickLength}
-          tickCount={horizontalAxis.tickCount}
-          tickSize={horizontalAxis.tickSize}
-          tickFormat={horizontalAxis.tickFormat}
+          position={horizontalAxis.position || Position.BOTTOM}
         />
         <Axis
-          position={
-            verticalAxis.position
-            || (isRTL ? Position.RIGHT : Position.LEFT)
-          }
+          {...verticalAxis}
           aScale={yScale}
-          title={verticalAxis.title}
-          titleAlign={verticalAxis.titleAlign}
-          tickLength={verticalAxis.tickLength}
-          tickCount={verticalAxis.tickCount}
-          tickSize={verticalAxis.tickSize}
-          tickFormat={verticalAxis.tickFormat}
+          position={
+            verticalAxis.position || (isRTL ? Position.RIGHT : Position.LEFT)
+          }
         />
       </Chart>
     );

--- a/packages/ez-vue/src/recipes/scatter/BubbleChart.tsx
+++ b/packages/ez-vue/src/recipes/scatter/BubbleChart.tsx
@@ -132,12 +132,9 @@ export default class BubbleChart extends Vue {
   private readonly isRTL!: boolean;
 
   @Prop({
-    type: Function as PropType<
-      (dimensions: Dimensions) => void
-    >,
+    type: Function as PropType<(dimensions: Dimensions) => void>,
     required: false,
   })
-
   get horizontalAxis() {
     return this.swapAxis ? this.yAxis : this.xAxis;
   }
@@ -206,25 +203,17 @@ export default class BubbleChart extends Vue {
           xScale={xScale}
           yScale={yScale}
         />
-        <Bubbles
-          xScale={xScale}
-          yScale={yScale}
-          rScale={rScale}
-        />
+        <Bubbles xScale={xScale} yScale={yScale} rScale={rScale} />
         <Axis
-          position={horizontalAxis.position || Position.BOTTOM}
-          aScale={xScale}
-          title={horizontalAxis.title}
-          titleAlign={horizontalAxis.titleAlign}
-          tickLength={horizontalAxis.tickLength}
-          tickCount={horizontalAxis.tickCount}
-          tickSize={horizontalAxis.tickLength}
-          tickFormat={horizontalAxis.tickFormat}
+          {...{
+            ...horizontalAxis,
+            aScale: xScale,
+            position: horizontalAxis.position || Position.BOTTOM,
+          }}
         />
         <Axis
           position={
-            verticalAxis.position
-            || (isRTL ? Position.RIGHT : Position.LEFT)
+            verticalAxis.position || (isRTL ? Position.RIGHT : Position.LEFT)
           }
           aScale={yScale}
           title={verticalAxis.title}

--- a/packages/ez-vue/src/recipes/scatter/BubbleChart.tsx
+++ b/packages/ez-vue/src/recipes/scatter/BubbleChart.tsx
@@ -231,7 +231,7 @@ export default class BubbleChart extends Vue {
           titleAlign={verticalAxis.titleAlign}
           tickLength={verticalAxis.tickLength}
           tickCount={verticalAxis.tickCount}
-          tickSize={verticalAxis.tickLength}
+          tickSize={verticalAxis.tickSize}
           tickFormat={verticalAxis.tickFormat}
         />
       </Chart>

--- a/packages/ez-vue/src/recipes/scatter/BubbleChart.tsx
+++ b/packages/ez-vue/src/recipes/scatter/BubbleChart.tsx
@@ -205,16 +205,19 @@ export default class BubbleChart extends Vue {
         />
         <Bubbles xScale={xScale} yScale={yScale} rScale={rScale} />
         <Axis
-          {...horizontalAxis}
-          aScale={xScale}
-          position={horizontalAxis.position || Position.BOTTOM}
+          props={{
+            ...horizontalAxis,
+            aScale: xScale,
+            position: horizontalAxis.position || Position.BOTTOM,
+          }}
         />
         <Axis
-          {...verticalAxis}
-          aScale={yScale}
-          position={
-            verticalAxis.position || (isRTL ? Position.RIGHT : Position.LEFT)
-          }
+          props={{
+            ...verticalAxis,
+            aScale: yScale,
+            position:
+              verticalAxis.position || (isRTL ? Position.RIGHT : Position.LEFT),
+          }}
         />
       </Chart>
     );

--- a/packages/ez-vue/src/recipes/scatter/ScatterChart.tsx
+++ b/packages/ez-vue/src/recipes/scatter/ScatterChart.tsx
@@ -214,7 +214,7 @@ export default class ScatterChart extends Vue {
           titleAlign={verticalAxis.titleAlign}
           tickLength={verticalAxis.tickLength}
           tickCount={verticalAxis.tickCount}
-          tickSize={verticalAxis.tickLength}
+          tickSize={verticalAxis.tickSize}
           tickFormat={verticalAxis.tickFormat}
         />
       </Chart>

--- a/packages/ez-vue/src/recipes/scatter/ScatterChart.tsx
+++ b/packages/ez-vue/src/recipes/scatter/ScatterChart.tsx
@@ -189,33 +189,18 @@ export default class ScatterChart extends Vue {
           xScale={xScale}
           yScale={yScale}
         />
-        <Points
-          xScale={xScale}
-          yScale={yScale}
-          r={point.radius}
-        />
+        <Points xScale={xScale} yScale={yScale} r={point.radius} />
         <Axis
-          position={horizontalAxis.position || Position.BOTTOM}
+          {...horizontalAxis}
           aScale={xScale}
-          title={horizontalAxis.title}
-          titleAlign={horizontalAxis.titleAlign}
-          tickLength={horizontalAxis.tickLength}
-          tickCount={horizontalAxis.tickCount}
-          tickSize={horizontalAxis.tickSize}
-          tickFormat={horizontalAxis.tickFormat}
+          position={horizontalAxis.position || Position.BOTTOM}
         />
         <Axis
-          position={
-            verticalAxis.position
-            || (isRTL ? Position.RIGHT : Position.LEFT)
-          }
+          {...verticalAxis}
           aScale={yScale}
-          title={verticalAxis.title}
-          titleAlign={verticalAxis.titleAlign}
-          tickLength={verticalAxis.tickLength}
-          tickCount={verticalAxis.tickCount}
-          tickSize={verticalAxis.tickSize}
-          tickFormat={verticalAxis.tickFormat}
+          position={
+            verticalAxis.position || (isRTL ? Position.RIGHT : Position.LEFT)
+          }
         />
       </Chart>
     );

--- a/packages/ez-vue/src/recipes/scatter/ScatterChart.tsx
+++ b/packages/ez-vue/src/recipes/scatter/ScatterChart.tsx
@@ -191,16 +191,19 @@ export default class ScatterChart extends Vue {
         />
         <Points xScale={xScale} yScale={yScale} r={point.radius} />
         <Axis
-          {...horizontalAxis}
-          aScale={xScale}
-          position={horizontalAxis.position || Position.BOTTOM}
+          props={{
+            ...horizontalAxis,
+            aScale: xScale,
+            position: horizontalAxis.position || Position.BOTTOM,
+          }}
         />
         <Axis
-          {...verticalAxis}
-          aScale={yScale}
-          position={
-            verticalAxis.position || (isRTL ? Position.RIGHT : Position.LEFT)
-          }
+          props={{
+            ...verticalAxis,
+            aScale: yScale,
+            position:
+              verticalAxis.position || (isRTL ? Position.RIGHT : Position.LEFT),
+          }}
         />
       </Chart>
     );

--- a/packages/ez-vue/src/recipes/scatter/ScatterChart.tsx
+++ b/packages/ez-vue/src/recipes/scatter/ScatterChart.tsx
@@ -195,19 +195,27 @@ export default class ScatterChart extends Vue {
           r={point.radius}
         />
         <Axis
-          {...{
-            ...horizontalAxis,
-            aScale: xScale,
-            position: horizontalAxis.position || Position.BOTTOM,
-          }}
+          position={horizontalAxis.position || Position.BOTTOM}
+          aScale={xScale}
+          title={horizontalAxis.title}
+          titleAlign={horizontalAxis.titleAlign}
+          tickLength={horizontalAxis.tickLength}
+          tickCount={horizontalAxis.tickCount}
+          tickSize={horizontalAxis.tickSize}
+          tickFormat={horizontalAxis.tickFormat}
         />
         <Axis
-          {...{
-            ...verticalAxis,
-            aScale: yScale,
-            position:
-              verticalAxis.position || (isRTL ? Position.RIGHT : Position.LEFT),
-          }}
+          position={
+            verticalAxis.position
+            || (isRTL ? Position.RIGHT : Position.LEFT)
+          }
+          aScale={yScale}
+          title={verticalAxis.title}
+          titleAlign={verticalAxis.titleAlign}
+          tickLength={verticalAxis.tickLength}
+          tickCount={verticalAxis.tickCount}
+          tickSize={verticalAxis.tickSize}
+          tickFormat={verticalAxis.tickFormat}
         />
       </Chart>
     );

--- a/packages/ez-vue/src/recipes/scatter/ScatterChart.tsx
+++ b/packages/ez-vue/src/recipes/scatter/ScatterChart.tsx
@@ -195,27 +195,19 @@ export default class ScatterChart extends Vue {
           r={point.radius}
         />
         <Axis
-          position={horizontalAxis.position || Position.BOTTOM}
-          aScale={xScale}
-          title={horizontalAxis.title}
-          titleAlign={horizontalAxis.titleAlign}
-          tickLength={horizontalAxis.tickLength}
-          tickCount={horizontalAxis.tickCount}
-          tickSize={horizontalAxis.tickLength}
-          tickFormat={horizontalAxis.tickFormat}
+          {...{
+            ...horizontalAxis,
+            aScale: xScale,
+            position: horizontalAxis.position || Position.BOTTOM,
+          }}
         />
         <Axis
-          position={
-            verticalAxis.position
-            || (isRTL ? Position.RIGHT : Position.LEFT)
-          }
-          aScale={yScale}
-          title={verticalAxis.title}
-          titleAlign={verticalAxis.titleAlign}
-          tickLength={verticalAxis.tickLength}
-          tickCount={verticalAxis.tickCount}
-          tickSize={verticalAxis.tickSize}
-          tickFormat={verticalAxis.tickFormat}
+          {...{
+            ...verticalAxis,
+            aScale: yScale,
+            position:
+              verticalAxis.position || (isRTL ? Position.RIGHT : Position.LEFT),
+          }}
         />
       </Chart>
     );


### PR DESCRIPTION
# Motivation

I find that for the **AreaChart, LineChart, LineErrorMarginChart, BubbleChart, ScatterChart** the **tickSize** property passed to **Axis** component is **horizontalAxis.tickLength**.
This PR will update the **tickSize** property to have the corresponding value **horizontalAxis.tickSize**.

Fixes #51 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have done the work for both react and vue
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (Storybook)
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes