### PR TITLE
fix: global verticalAxis Tick Rotation with enabled RTL

### DIFF
--- a/packages/ez-core/src/utils/axis.ts
+++ b/packages/ez-core/src/utils/axis.ts
@@ -159,7 +159,8 @@ const calculateAxisTickRotation = (
   scale: D3ContuniousScales | D3CategoricalScales,
   labels: SVGGraphicsElement[],
   position: Position,
-  rotation: number | 'auto'
+  rotation: number | 'auto',
+  reverse: boolean
 ) => {
   const { maxHeight, maxWidth, labelCount } = measureAxisLabels(labels);
   const measuredSize = labelCount * maxWidth;
@@ -169,7 +170,7 @@ const calculateAxisTickRotation = (
   // The more the overlap, the more we rotate
   let rotate: number;
   if (rotation === 'auto' && typeof scale !== 'undefined') {
-    const range = scale.range()[1] as number;
+    const range = scale.range()[reverse ? 0 : 1] as number;
     rotate =
       range < measuredSize
         ? 90 * Math.min(1, (measuredSize / range - 0.8) / 2)
@@ -192,13 +193,15 @@ export const getAxisLabelAttributes = (
   scale: D3ContuniousScales | D3CategoricalScales,
   elements: SVGGraphicsElement[],
   position: Position,
-  rotation: number | 'auto'
+  rotation: number | 'auto',
+  reverse: boolean
 ) => {
   const { rotate, maxHeight, anchor } = calculateAxisTickRotation(
     scale,
     elements,
     position,
-    rotation
+    rotation,
+    reverse
   );
   const sign =
     position === Position.TOP || position === Position.LEFT ? -1 : 1;

--- a/packages/ez-react/src/components/scales/Axis.tsx
+++ b/packages/ez-react/src/components/scales/Axis.tsx
@@ -80,7 +80,13 @@ export const Axis: FC<AxisProps> = ({
 
   const axisLabelTransform = useMemo(() => {
     const labels = labelsRef.current.filter((el) => !!el) as SVGTextElement[];
-    return getAxisLabelAttributes(aScale.scale, labels, position, 'auto');
+    return getAxisLabelAttributes(
+      aScale.scale,
+      labels,
+      position,
+      'auto',
+      aScale.definition.reverse
+    );
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentAxis]);
 

--- a/packages/ez-vue/src/components/scales/Axis.tsx
+++ b/packages/ez-vue/src/components/scales/Axis.tsx
@@ -117,6 +117,7 @@ export default class Axis extends Vue {
         labels,
         this.position,
         'auto',
+        this.aScale.definition.reverse,
       );
     });
   }


### PR DESCRIPTION
# Motivation

I find that for the Area Chart, Bar Chart, Line Chart, Scatter Chart when we enable the RTL the Tick situated in the verticalAxis do an extra rotation.

Fixes #53 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have done the work for both react and vue
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (Storybook)
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
