### PR TITLE
fix: fixed collision between Y axis title and axis ticks text

### DIFF
--- a/packages/ez-core/src/utils/axis.ts
+++ b/packages/ez-core/src/utils/axis.ts
@@ -38,10 +38,12 @@ export const getAxisTitleProps = (
   position: Position,
   dimensions: Dimensions,
   padding: ChartPadding,
-  titleAlign: Anchor
+  titleAlign: Anchor,
+  maxTickWidth: Number
 ) => {
+  // sets the Y axis title position
   if (position === Position.LEFT || position === Position.RIGHT) {
-    const x = 0;
+    const x = maxTickWidth > 60 ? -60 : -maxTickWidth / 2;
     const dy =
       (position === Position.RIGHT ? padding.right : -padding.left) / 2;
     let y = dimensions.height / 2;
@@ -55,7 +57,9 @@ export const getAxisTitleProps = (
       transform: `translate(${x},${y}) rotate(-90)`,
       dy,
     };
-  } else {
+  }
+  // sets the X axis title position
+  else {
     let x = dimensions.width / 2;
     const y = 0;
     const dy =
@@ -109,15 +113,10 @@ export const getGridLines = (
 ) => {
   const isHorizontal = direction === Direction.HORIZONTAL;
   const position = isHorizontal ? Position.BOTTOM : Position.LEFT;
-  return getAxis(
-    position,
-    scale,
-    dimensions,
-    {
-      tickCount,
-      tickSize: isHorizontal ? dimensions.height : dimensions.width
-    }
-  );
+  return getAxis(position, scale, dimensions, {
+    tickCount,
+    tickSize: isHorizontal ? dimensions.height : dimensions.width,
+  });
 };
 
 export const getAxisTickByCoordinate = (
@@ -136,13 +135,13 @@ const measureAxisLabels = (labels: SVGGraphicsElement[]) => {
     };
   }
 
-  const boundingBoxes = labels.map((l) => {
+  const boundingBoxes = labels.map(l => {
     return typeof l.getBBox === 'function'
       ? l.getBBox()
       : { width: 0, height: 0 };
   });
-  const maxHeight = Math.max(...boundingBoxes.map((b) => b.height));
-  const maxWidth = Math.max(...boundingBoxes.map((b) => b.width));
+  const maxHeight = Math.max(...boundingBoxes.map(b => b.height));
+  const maxWidth = Math.max(...boundingBoxes.map(b => b.width));
   return {
     maxHeight,
     maxWidth,
@@ -169,8 +168,7 @@ const calculateAxisTickRotation = (
 ) => {
   const { maxHeight, maxWidth, labelCount } = measureAxisLabels(labels);
   const measuredSize = labelCount * maxWidth;
-  const sign =
-    position === Position.TOP || position === Position.LEFT ? -1 : 1;
+  const sign = position === Position.TOP || position === Position.LEFT ? -1 : 1;
 
   // The more the overlap, the more we rotate
   let rotate: number;
@@ -201,20 +199,20 @@ export const getAxisLabelAttributes = (
   rotation: number | 'auto',
   reverse: boolean
 ) => {
-  const { rotate, maxHeight, anchor } = calculateAxisTickRotation(
+  const { rotate, maxHeight, maxWidth, anchor } = calculateAxisTickRotation(
     scale,
     elements,
     position,
     rotation,
     reverse
   );
-  const sign =
-    position === Position.TOP || position === Position.LEFT ? -1 : 1;
+  const sign = position === Position.TOP || position === Position.LEFT ? -1 : 1;
   const offset = sign * Math.floor(maxHeight / 2);
   const offsetTransform = isVerticalPosition(position)
     ? `translate(${offset}, 0)`
     : `translate(0, ${offset})`;
   return {
+    maxWidth,
     textAnchor: anchor,
     transform: `${offsetTransform} rotate(${rotate} 0 0)`,
   };

--- a/packages/ez-react/src/components/scales/Axis.tsx
+++ b/packages/ez-react/src/components/scales/Axis.tsx
@@ -91,8 +91,17 @@ export const Axis: FC<AxisProps> = ({
   }, [currentAxis]);
 
   const titleProps = useMemo(() => {
-    return getAxisTitleProps(position, dimensions, padding, titleAlign);
-  }, [position, dimensions, padding, titleAlign]);
+    // using the tick text max width to help set the distance between the Y axis title and the ticks
+    const { maxWidth } = axisLabelTransform;
+    return getAxisTitleProps(
+      position,
+      dimensions,
+      padding,
+      titleAlign,
+      maxWidth
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentAxis, position, dimensions, padding, titleAlign]);
 
   return (
     <g
@@ -115,6 +124,9 @@ export const Axis: FC<AxisProps> = ({
                 y2={getTick(tick.line.y2 || 0)}
                 className="ez-axis-tick-line"
               />
+              <title>
+                {tick.text.text.replace(/(\.\d{1}).*$/, (_a, c) => c)}
+              </title>
               <text
                 x={tick.text.x}
                 y={tick.text.y}
@@ -124,7 +136,10 @@ export const Axis: FC<AxisProps> = ({
                 className="ez-axis-tick-text"
                 ref={(el) => (labelsRef.current[index] = el)}
               >
-                {tick.text.text.replace(/(\.\d{1}).*$/, (_a, c) => c)}
+                {tick.text.text
+                  .replace(/(\.\d{1}).*$/, (_a, c) => c)
+                  .substring(0, 7)}
+                {tick.text.text.length > 7 ? '...' : ''}
               </text>
             </g>
           );

--- a/packages/ez-react/src/recipes/area/AreaChart.tsx
+++ b/packages/ez-react/src/recipes/area/AreaChart.tsx
@@ -58,7 +58,7 @@ export const AreaChart: FC<AreaChartProps> = ({
     delay: 0,
   },
   padding = {
-    left: 100,
+    left: 150,
     bottom: 100,
     right: 100,
     top: 100,

--- a/packages/ez-react/src/recipes/line/LineChart.tsx
+++ b/packages/ez-react/src/recipes/line/LineChart.tsx
@@ -53,7 +53,7 @@ export const LineChart: FC<LineChartProps> = ({
     delay: 0,
   },
   padding = {
-    left: 100,
+    left: 150,
     bottom: 100,
     right: 100,
     top: 100,

--- a/packages/ez-react/src/recipes/line/LineErrorMarginChart.tsx
+++ b/packages/ez-react/src/recipes/line/LineErrorMarginChart.tsx
@@ -68,7 +68,7 @@ export const LineErrorMarginChart: FC<LineErrorMarginChartProps> = ({
     delay: 0,
   },
   padding = {
-    left: 100,
+    left: 150,
     bottom: 100,
     right: 100,
     top: 100,

--- a/packages/ez-react/src/recipes/line/MultiLineChart.tsx
+++ b/packages/ez-react/src/recipes/line/MultiLineChart.tsx
@@ -61,7 +61,7 @@ export const MultiLineChart: FC<MultiLineChartProps> = ({
     delay: 0,
   },
   padding = {
-    left: 100,
+    left: 150,
     bottom: 100,
     right: 100,
     top: 100,

--- a/packages/ez-react/src/recipes/scatter/BubbleChart.tsx
+++ b/packages/ez-react/src/recipes/scatter/BubbleChart.tsx
@@ -48,7 +48,7 @@ export const BubbleChart: FC<BubbleChartProps> = ({
     delay: 0,
   },
   padding = {
-    left: 100,
+    left: 150,
     bottom: 100,
     right: 100,
     top: 100,

--- a/packages/ez-react/src/recipes/scatter/ScatterChart.tsx
+++ b/packages/ez-react/src/recipes/scatter/ScatterChart.tsx
@@ -45,7 +45,7 @@ export const ScatterChart: FC<ScatterChartProps> = ({
     delay: 0,
   },
   padding = {
-    left: 100,
+    left: 150,
     bottom: 100,
     right: 100,
     top: 100,

--- a/packages/ez-vue/src/components/scales/Axis.tsx
+++ b/packages/ez-vue/src/components/scales/Axis.tsx
@@ -83,6 +83,7 @@ export default class Axis extends Vue {
   private axisLabelTransform = {
     textAnchor: Anchor.MIDDLE,
     transform: 'translate(0, 0) rotate(0 0 0)',
+    maxWidth: 0,
   };
 
   updateCurrentAxis() {
@@ -167,11 +168,13 @@ export default class Axis extends Vue {
   }
 
   get titleProps() {
+    const { maxWidth } = this.axisLabelTransform;
     return getAxisTitleProps(
       this.position,
       this.chart.dimensions,
       this.chart.padding,
       this.titleAlign,
+      maxWidth,
     );
   }
 
@@ -205,6 +208,9 @@ export default class Axis extends Vue {
               x2={getTick(tick.line.x2)}
               y2={getTick(tick.line.y2)}
             />
+            <title>
+              {tick.text.text.replace(/(\.\d{1}).*$/, (_a, c) => c)}
+            </title>
             <text
               x={tick.text.x}
               y={tick.text.y}
@@ -213,7 +219,10 @@ export default class Axis extends Vue {
               transform={axisLabelTransform.transform}
               class="ez-axis-tick-text"
             >
-              {tick.text.text.toString().replace(/(\.\d{1}).*$/, (_a, c) => c)}
+              {tick.text.text
+                .replace(/(\.\d{1}).*$/, (_a, c) => c)
+                .substring(0, 7)}
+              {tick.text.text.length > 7 ? '...' : ''}
             </text>
           </g>
         ))}


### PR DESCRIPTION
# Motivation
This PR fixes the Y axis title and tick text collision issue. 

Fixes #57 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I have done the work for both react and vue
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (Storybook)
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
