### PR TITLE
fix: rtl revert data order

### DIFF
--- a/packages/ez-react/src/components/Chart.tsx
+++ b/packages/ez-react/src/components/Chart.tsx
@@ -117,8 +117,8 @@ export const Chart: FC<ChartProps> = ({
 
   const chartData = useMemo(() => {
     const values = Object.values(dataDict);
-    return isRTL ? values.reverse() : values;
-  }, [dataDict, isRTL]);
+    return values;
+  }, [dataDict]);
 
   const onLegendResize = useCallback(
     ({ height }: Dimensions) => setLegendHeight(height),

--- a/packages/ez-react/src/recipes/column/ColumnChart.tsx
+++ b/packages/ez-react/src/recipes/column/ColumnChart.tsx
@@ -91,6 +91,7 @@ export const ColumnChart: FC<ColumnChartProps> = ({
           definition: {
             direction: Direction.HORIZONTAL,
             domainKey: xAxis.domainKey,
+            reverse: isRTL,
           },
         }}
         yScaleConfig={{

--- a/packages/ez-react/src/recipes/column/LineColumnChart.tsx
+++ b/packages/ez-react/src/recipes/column/LineColumnChart.tsx
@@ -95,6 +95,7 @@ export const LineColumnChart: FC<LineColumnChartProps> = ({
           definition: {
             direction: Direction.HORIZONTAL,
             domainKey: xAxis.domainKey,
+            reverse: isRTL,
           },
         }}
         yScaleConfig={{
@@ -122,6 +123,7 @@ export const LineColumnChart: FC<LineColumnChartProps> = ({
           definition: {
             direction: Direction.HORIZONTAL,
             domainKey: xAxis.domainKey,
+            reverse: isRTL,
           },
         }}
         yScaleConfig={{

--- a/packages/ez-vue/src/components/Chart.tsx
+++ b/packages/ez-vue/src/components/Chart.tsx
@@ -152,7 +152,7 @@ export default class Chart extends Vue {
   @Watch('chart.dataDict', { deep: true })
   onDataDictChange() {
     const data = Object.values(this.chart.dataDict);
-    this.chart.data = this.isRTL ? data.reverse() : data;
+    this.chart.data = data;
   }
 
   @Watch('isRTL')

--- a/packages/ez-vue/src/recipes/column/ColumnChart.tsx
+++ b/packages/ez-vue/src/recipes/column/ColumnChart.tsx
@@ -170,6 +170,7 @@ export default class ColumnChart extends mixins(ToggleDatumMixin) {
             definition: {
               direction: Direction.HORIZONTAL,
               domainKey: xAxis.domainKey,
+              reverse: isRTL,
             },
           }}
           yScaleConfig={{

--- a/packages/ez-vue/src/recipes/column/LineColumnChart.tsx
+++ b/packages/ez-vue/src/recipes/column/LineColumnChart.tsx
@@ -218,6 +218,7 @@ export default class LineColumnChart extends mixins(ToggleDatumMixin) {
             definition: {
               direction: Direction.HORIZONTAL,
               domainKey: xAxis.domainKey,
+              reverse: isRTL,
             },
           }}
           yScaleConfig={{
@@ -255,6 +256,7 @@ export default class LineColumnChart extends mixins(ToggleDatumMixin) {
             definition: {
               direction: Direction.HORIZONTAL,
               domainKey: xAxis.domainKey,
+              reverse: isRTL,
             },
           }}
           yScaleConfig={{


### PR DESCRIPTION
# Motivation

I find an issue of representation order with RTL enabled in Bar Chart, Column chart and Line Column Chart.
This PR fixes this issue.

Fixes #90 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have done the work for both react and vue
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (Storybook)
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
