### PR TITLE
fix: storybook area fill color

### DIFF
--- a/packages/ez-react/src/recipes/area/AreaChart.stories.tsx
+++ b/packages/ez-react/src/recipes/area/AreaChart.stories.tsx
@@ -53,8 +53,8 @@ const defaultArguments = flattenArgs({
   area: {
     stroke: colors[0],
     strokeWidth: 2,
-    fill: `${colors[0]}b0`,
-    opacity: 1,
+    fill: colors[0],
+    opacity: 0.5,
   },
   marker: {
     hidden: true,

--- a/packages/ez-vue/src/recipes/area/AreaChart.stories.tsx
+++ b/packages/ez-vue/src/recipes/area/AreaChart.stories.tsx
@@ -58,9 +58,9 @@ const defaultArguments = flattenArgs({
   area: {
     stroke: colors[0],
     strokeWidth: 2,
-    fill: `${colors[0]}b0`,
+    fill: colors[0],
     beta: 0,
-    opacity: 1,
+    opacity: 0.5,
   },
   marker: {
     hidden: true,


### PR DESCRIPTION
# Motivation

Minor fix for storybook default fill color arg for Area Chart.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] I have done the work for both react and vue
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (Storybook)
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
