### PR TITLE
fix: map chart dimensions default prop value

### DIFF
--- a/packages/ez-react/src/recipes/map/MapChart.tsx
+++ b/packages/ez-react/src/recipes/map/MapChart.tsx
@@ -11,7 +11,6 @@ import { Map } from '@/components/Map';
 import { LegendProps } from '@/components/addons/legend/Legend';
 import { Tooltip, TooltipProps } from '@/components/addons/tooltip/Tooltip';
 import { Chart } from '@/components/Chart';
-import { dimensions } from 'eazychart-dev/storybook/data';
 import { ColorScale } from '@/components/scales/ColorScale';
 
 export interface MapChartProps extends SVGAttributes<SVGGElement> {
@@ -50,6 +49,7 @@ export const MapChart: FC<MapChartProps> = ({
     right: 100,
     top: 100,
   },
+  dimensions = {},
   scopedSlots = {
     // @todo : support Legend
     // LegendComponent: Legend,

--- a/packages/ez-vue/src/recipes/map/MapChart.tsx
+++ b/packages/ez-vue/src/recipes/map/MapChart.tsx
@@ -30,7 +30,9 @@ import ColorScale from '@/components/scales/ColorScale';
 export default class MapChart extends Vue {
   @Prop({
     type: Object as PropType<Dimensions>,
-    required: true,
+    default() {
+      return {};
+    },
   })
   private readonly dimensions!: Partial<Dimensions>;
 


### PR DESCRIPTION
# Motivation

The dimensions prop default value for the map chart, shouldn't be getting the value from the ez-dev pkg. 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] I have done the work for both react and vue
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (Storybook)
- [X] I have added unit tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
