### PR TITLE
fix: contructor.name

### DIFF
--- a/packages/ez-react/src/components/Area.tsx
+++ b/packages/ez-react/src/components/Area.tsx
@@ -32,11 +32,8 @@ export const Area: FC<AreaProps> = ({
 
   const color = useMemo(() => {
     if (colorScale.isDefined()) {
-      if (colorScale.constructor.name === 'ScaleOrdinal') {
-        return (colorScale as any as ScaleOrdinal).scale(yDomainKey);
-      } else {
-        throw new Error('Area shape does not support non ordinal color scale');
-      }
+      // Area shape does not support non ordinal color scale
+      return (colorScale as any as ScaleOrdinal).scale(yDomainKey);
     }
     return area.fill;
   }, [area.fill, colorScale, yDomainKey]);

--- a/packages/ez-react/src/components/Segments.tsx
+++ b/packages/ez-react/src/components/Segments.tsx
@@ -32,11 +32,8 @@ export const Segments: FC<SegmentsProps> = ({
 
   const color = useMemo(() => {
     if (colorScale.isDefined()) {
-      if (colorScale.constructor.name === 'ScaleOrdinal') {
-        return (colorScale as any as ScaleOrdinal).scale(yDomainKey);
-      } else {
-        throw new Error('Segments does not support non ordinal color scale');
-      }
+      // Segment shape does not support non ordinal color scale
+      return (colorScale as any as ScaleOrdinal).scale(yDomainKey);
     }
     return line.stroke;
   }, [colorScale, yDomainKey, line]);

--- a/packages/ez-vue/src/components/Area.tsx
+++ b/packages/ez-vue/src/components/Area.tsx
@@ -58,10 +58,8 @@ export default class Area extends Vue {
   get color() {
     const { colorScale, yDomainKey, area } = this;
     if (colorScale && colorScale.isDefined()) {
-      if (colorScale.constructor.name === 'ScaleOrdinal') {
-        return colorScale.scale(yDomainKey);
-      }
-      throw new Error('Area shape does not support non ordinal color scale');
+      // Area shape does not support non ordinal color scale
+      return (colorScale as any as ScaleOrdinal).scale(yDomainKey);
     }
     return area.fill;
   }

--- a/packages/ez-vue/src/components/Segments.tsx
+++ b/packages/ez-vue/src/components/Segments.tsx
@@ -51,12 +51,8 @@ export default class Segments extends Vue {
   get color() {
     const { colorScale, yDomainKey, line } = this;
     if (colorScale && colorScale.isDefined()) {
-      if (colorScale.constructor.name === 'ScaleOrdinal') {
-        return colorScale.scale(yDomainKey);
-      }
-      throw new Error(
-        'Segments shape does not support non ordinal color scale',
-      );
+      // Segments shape does not support non ordinal color scale
+      return (colorScale as any as ScaleOrdinal).scale(yDomainKey);
     }
     return line.stroke;
   }


### PR DESCRIPTION
# Motivation

This PR is a "temporary" fix for the following issue : https://github.com/Hexastack/eazychart/issues/107

We need a type safe-guard for the certain shapes that would be included under the color scale context provider. Shapes like Segments or Area do not support non ordinal scale. So we need to find a solution in the future on how to make the developer aware of that while coding recipes. 

Fixes # [(issue)](https://github.com/Hexastack/eazychart/issues/107)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] I have done the work for both react and vue
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (Storybook)
- [X] I have added unit tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
