### PR TITLE
feat: refactor map into ctx provider + add bubble map chart

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eazychart-monorepo",
-  "version": 0.0.1,
+  "version": "0.0.1",
   "description": "EazyChart is an easy to use reactive library that allows you to add customizable charts into your React or Vue web applications.",
   "keywords": ["chart", "library", "svg", "react", "dataviz", "graph", "typescript", "javascript", "data", "visualization", "web"],
   "author": "Hexastack",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "eazychart-monorepo",
+  "version": 0.0.1,
   "description": "EazyChart is an easy to use reactive library that allows you to add customizable charts into your React or Vue web applications.",
   "keywords": ["chart", "library", "svg", "react", "dataviz", "graph", "typescript", "javascript", "data", "visualization", "web"],
   "author": "Hexastack",

--- a/packages/ez-core/src/index.ts
+++ b/packages/ez-core/src/index.ts
@@ -21,6 +21,7 @@ export {
   ScaleSequentialPower,
   ScaleSequentialSqrt,
   ScaleSequentialSymLog,
+  ScaleSqrt,
   ScaleThreshold,
   ScaleQuantize,
   ScaleQuantile,

--- a/packages/ez-core/src/scales/index.ts
+++ b/packages/ez-core/src/scales/index.ts
@@ -20,6 +20,7 @@ export { default as ScaleSequentialLogarithmic } from './ScaleSequentialLogarith
 export { default as ScaleSequentialPower } from './ScaleSequentialPower';
 export { default as ScaleSequentialSqrt } from './ScaleSequentialSqrt';
 export { default as ScaleSequentialSymLog } from './ScaleSequentialSymLog';
+export { default as ScaleSqrt } from './ScaleSqrt';
 export { default as ScaleThreshold } from './ScaleThreshold';
 export { default as ScaleQuantize } from './ScaleQuantize';
 export { default as ScaleQuantile } from './ScaleQuantile';

--- a/packages/ez-core/src/types.ts
+++ b/packages/ez-core/src/types.ts
@@ -93,5 +93,10 @@ export interface BubbleConfig {
   domainKey: string;
   minRadius: number;
   maxRadius: number;
-  fill: string;
+  // @TODO: Enhance so that we have either fill or colors
+  fill?: string;
+  colors?: string[];
+  stroke?: string;
+  strokeWidth?: number;
+  opacity?: number;
 }

--- a/packages/ez-core/src/utils/defaults.ts
+++ b/packages/ez-core/src/utils/defaults.ts
@@ -114,9 +114,9 @@ export const defaultChartContext: ChartContext = {
 
 export const defaultMapContext: MapContext = {
   mapData: [],
-  ...computeMapProjection('geoMercator', {
+  projection: computeMapProjection('geoMercator', {
     offset: [0, 0],
     center: [0, 0],
-    scale: 0
-  })
+    scale: 0,
+  }),
 };

--- a/packages/ez-core/src/utils/defaults.ts
+++ b/packages/ez-core/src/utils/defaults.ts
@@ -7,9 +7,11 @@ import {
   ChartContext,
   TooltipContext,
   ShapeDatum,
+  MapContext,
 } from './types';
 import { Point, Anchor, Dimensions, ShapeAttributes } from '../types';
 import { AnimationOptions } from '../animation/types';
+import { computeMapProjection } from './map';
 
 export const defaultColor = '#1f77b4';
 
@@ -108,4 +110,13 @@ export const defaultChartContext: ChartContext = {
   isRTL: false,
   registerScale: () => {},
   getScale: () => null,
+};
+
+export const defaultMapContext: MapContext = {
+  mapData: [],
+  ...computeMapProjection('geoMercator', {
+    offset: [0, 0],
+    center: [0, 0],
+    scale: 0
+  })
 };

--- a/packages/ez-core/src/utils/map.ts
+++ b/packages/ez-core/src/utils/map.ts
@@ -5,7 +5,6 @@ import {
   GeoProjectionViewport,
   GeoProjectionType,
   GeoProjection,
-  GeoPathGenerator,
 } from './types';
 
 export const calculateGeoProjectionViewport = (
@@ -44,7 +43,7 @@ export const calculateGeoProjectionViewport = (
 export const computeMapProjection = (
   projectionType: GeoProjectionType,
   { center, scale, offset }: GeoProjectionViewport
-): { projection: GeoProjection; geoPathGenerator: GeoPathGenerator } => {
+): GeoProjection => {
   if (!(projectionType in d3Geo)) {
     throw new Error('Uknown projection type provided!');
   }
@@ -55,8 +54,9 @@ export const computeMapProjection = (
   projection.scale(scale);
   projection.translate(offset);
 
-  return {
-    projection,
-    geoPathGenerator: d3Geo.geoPath(projection),
-  };
+  return projection;
 };
+
+export const getGeoPathByProjection = (projection: GeoProjection) => {
+  return d3Geo.geoPath(projection);
+}

--- a/packages/ez-core/src/utils/scale.ts
+++ b/packages/ez-core/src/utils/scale.ts
@@ -1,5 +1,4 @@
 import { pie } from 'd3-shape';
-import { geoCentroid } from 'd3-geo';
 import { ScaleBand, ScaleLinear, ScaleSqrt } from '../scales';
 import {
   ArrayOfTwoNumbers,
@@ -14,10 +13,11 @@ import {
   ArcDatum,
   GeoFeatureData,
   GeoFeatures,
-  GeoPathGenerator,
+  GeoProjection,
   PointDatum,
   RectangleDatum,
 } from './types';
+import { getGeoPathByProjection } from '../utils/map'
 
 export const scaleDatumValue = <T = string | number>(
   datum: NormalizedDatum,
@@ -251,9 +251,11 @@ export const scaleGeoFeatureData = (
   features: GeoFeatures,
   geoDomainKey: string,
   valueDomainKey: string,
+  projection: GeoProjection,
   colorScale: AnyScale | undefined,
-  defaultColor: string
+  defaultColor: string,
 ): GeoFeatureData => {
+  const geoPath = getGeoPathByProjection(projection)
   return features.map((feature, idx) => {
     let color = defaultColor;
     let id: string = `${feature.id || idx}`;
@@ -284,7 +286,7 @@ export const scaleGeoFeatureData = (
       );
     }
 
-    const [x, y] = geoCentroid(feature);
+    const [x, y] = geoPath.centroid(feature);
     return {
       id,
       color,
@@ -297,18 +299,19 @@ export const scaleGeoFeatureData = (
 export const scaleMapBubbleData = (
   data: NormalizedData,
   mapData: GeoFeatureData,
-  geoPathGenerator: GeoPathGenerator,
+  projection: GeoProjection,
   rDomainKey: string,
   rScale: ScaleSqrt,
   colorScale: AnyScale
 ): PointDatum[] => {
+  const geoPath = getGeoPathByProjection(projection)
   return mapData.map(shapeDatum => {
     const datum = data.find(
       datum => rDomainKey in datum && datum.id === shapeDatum.id
     );
     if (datum) {
       const v = datum[rDomainKey] as number;
-      const [x, y] = geoPathGenerator.centroid(shapeDatum.feature);
+      const [x, y] = geoPath.centroid(shapeDatum.feature);
       return {
         id: shapeDatum.id,
         x,

--- a/packages/ez-core/src/utils/types.ts
+++ b/packages/ez-core/src/utils/types.ts
@@ -12,7 +12,6 @@ import {
   Dimensions,
   NormalizedData,
   NormalizedDataDict,
-  NormalizedDatum,
   Point,
   ScaleBandDefinition,
   ScaleLinearDefinition,
@@ -96,6 +95,12 @@ export interface ChartContext {
   onLegendClick?: (key: string, isActive: boolean, color: string) => void;
 }
 
+export interface MapContext {
+  mapData: GeoFeatureData;
+  projection: GeoProjection;
+  geoPathGenerator: GeoPathGenerator;
+}
+
 export type TooltipContext = {
   showTooltip: (_datum: ShapeDatum, _event: MouseEvent) => void;
   hideTooltip: (_datum: ShapeDatum, _event: MouseEvent) => void;
@@ -155,6 +160,7 @@ export type GeoFeatureCollection = FeatureCollection<Geometry, GeoJsonProperties
 export type GeoFeatures = FeatureCollection['features'];
 
 export type GeoProjection = d3Geo.GeoProjection;
+export type GeoPathGenerator = d3Geo.GeoPath;
 
 export type GeoProjectionType = keyof Pick<
   typeof d3Geo,
@@ -174,20 +180,18 @@ export type GeoProjectionType = keyof Pick<
   | 'geoNaturalEarth1'
 >;
 
-export type GeoProjectionCenter = {
+export type GeoProjectionViewport = {
   center: [number, number],
   scale: number,
   offset: [number, number]
 }
 
-export type GeoFeatureDatum = GeoFeature & ShapeAttributes;
-
-export type GeoFeatureDataDict = {
-  [geoDomainKey: string]: {
-    feature: GeoFeature;
-    datum: NormalizedDatum | undefined;
-  };
+export type GeoFeatureDatum = ShapeAttributes & {
+  feature: GeoFeature;
+  centroid: Point;
 };
+
+export type GeoFeatureData = GeoFeatureDatum[];
 
 export type MapConfig = {
   geoDomainKey: string;

--- a/packages/ez-core/src/utils/types.ts
+++ b/packages/ez-core/src/utils/types.ts
@@ -98,7 +98,6 @@ export interface ChartContext {
 export interface MapContext {
   mapData: GeoFeatureData;
   projection: GeoProjection;
-  geoPathGenerator: GeoPathGenerator;
 }
 
 export type TooltipContext = {

--- a/packages/ez-dev/storybook/data.ts
+++ b/packages/ez-dev/storybook/data.ts
@@ -1,7 +1,7 @@
 import {
   AnimationOptions,
   ChartPadding,
-  GeoJsonData,
+  GeoFeatureCollection,
   RawData,
 } from 'eazychart-core/src/types';
 
@@ -92,4 +92,12 @@ export const animationOptions: AnimationOptions = {
   delay: 0,
 };
 
-export const mapData = GEOJSON_MAP as GeoJsonData;
+export const mapGeoJson = (GEOJSON_MAP as GeoFeatureCollection);
+
+export const mapData = (GEOJSON_MAP as GeoFeatureCollection).features.map(({ properties }) => {
+  return {
+    admin: properties?.admin,
+    value: properties?.pop_rank,
+    rValue: properties?.gdp_md,
+  };
+})

--- a/packages/ez-dev/storybook/storybook-configs.ts
+++ b/packages/ez-dev/storybook/storybook-configs.ts
@@ -44,10 +44,31 @@ const BETA_CONTROL: ControlDefinition = {
     'Determines the straigthness of the spline !! only works with curveBundle !!',
 };
 
+const FILL_CONTROL: ControlDefinition = {
+  name: 'fill',
+  type: 'color',
+  defaultValue: 'rgba(209, 46, 84, 0.5)',
+};
+
+const STROKE_CONTROL: ControlDefinition = {
+  name: 'stroke',
+  type: 'color',
+  defaultValue: '#ffffff',
+};
+
 const STROKE_WIDTH_CONTROL: ControlDefinition = {
   name: 'strokeWidth',
   type: 'number',
   defaultValue: '2 or 0 px',
+};
+
+const OPACITY_CONTROL: ControlDefinition = {
+  name: 'opacity',
+  type: 'range',
+  min: 0,
+  max: 1,
+  step: 0.1,
+  defaultValue: '0.5',
 };
 
 const CURVE_CONTROL: ControlDefinition = {
@@ -261,17 +282,22 @@ export const BUBBLE_CONTROLS: ControlDefinition[] = [
     defaultValue: 'rValue',
   },
   {
-    name: 'fill',
-    type: 'color',
-    defaultValue: 'rgba(209, 46, 84, 0.5)',
+    name: 'colors',
+    type: 'object',
   },
+  FILL_CONTROL,
+  {
+    ...STROKE_CONTROL,
+    defaultValue: 'rgba(0, 0, 0, 1)',
+  },
+  STROKE_WIDTH_CONTROL,
+  OPACITY_CONTROL,
 ];
 
 export const LINE_CONTROLS: ControlDefinition[] = [
   CURVE_CONTROL,
   {
-    name: 'stroke',
-    type: 'color',
+    ...STROKE_CONTROL,
     defaultValue: '#ef476f',
   },
   STROKE_WIDTH_CONTROL,
@@ -306,8 +332,7 @@ export const ARC_CONTROLS: ControlDefinition[] = [
     defaultValue: '0',
   },
   {
-    name: 'stroke',
-    type: 'color',
+    ...STROKE_CONTROL,
     defaultValue: 'Transparent',
   },
   STROKE_WIDTH_CONTROL,
@@ -316,25 +341,16 @@ export const ARC_CONTROLS: ControlDefinition[] = [
 export const AREA_CONTROLS: ControlDefinition[] = [
   CURVE_CONTROL,
   BETA_CONTROL,
-  STROKE_WIDTH_CONTROL,
   {
-    name: 'stroke',
-    type: 'color',
+    ...STROKE_CONTROL,
     defaultValue: '#26547c',
   },
+  STROKE_WIDTH_CONTROL,
   {
-    name: 'fill',
-    type: 'color',
+    ...FILL_CONTROL,
     defaultValue: '#26547cb0',
   },
-  {
-    name: 'opacity',
-    type: 'range',
-    min: 0,
-    max: 1,
-    step: 0.1,
-    defaultValue: '0.5',
-  },
+  OPACITY_CONTROL,
 ];
 
 export const MAP_CONTROLS: ControlDefinition[] = [
@@ -348,14 +364,9 @@ export const MAP_CONTROLS: ControlDefinition[] = [
     type: 'text',
     defaultValue: 'value',
   },
+  STROKE_CONTROL,
   {
-    name: 'stroke',
-    type: 'color',
-    defaultValue: '#ffffff',
-  },
-  {
-    name: 'fill',
-    type: 'color',
+    ...FILL_CONTROL,
     defaultValue: '#324678',
   },
   {

--- a/packages/ez-react/src/components/Map.tsx
+++ b/packages/ez-react/src/components/Map.tsx
@@ -1,34 +1,49 @@
 import React, { SVGAttributes, useMemo } from 'react';
 import {
-  calculateGeoProjectionCenter,
+  calculateGeoProjectionViewport,
+  computeMapProjection,
   scaleGeoFeatureData,
 } from 'eazychart-core/src';
-import { GeoFeatureCollection, MapConfig } from 'eazychart-core/src/types';
+import { GeoJsonData, MapConfig } from 'eazychart-core/src/types';
 import { MapPath } from './shapes/MapPath';
 import { useColorScale } from './scales/ColorScale';
 import { useChart } from '@/lib/use-chart';
+import { MapContext } from '@/lib/use-map';
 
-export interface MapChartProps extends SVGAttributes<SVGPathElement> {
+export interface MapProps extends SVGAttributes<SVGPathElement> {
   isWrapped?: boolean;
   map: MapConfig;
-  geoJson: GeoFeatureCollection;
+  geoJson: GeoJsonData;
+  children?: React.ReactNode;
 }
 
-export const Map: React.FC<MapChartProps> = ({
+export const Map: React.FC<MapProps> = ({
   geoJson,
-  map,
+  map: { projectionType, geoDomainKey, valueDomainKey, fill, stroke },
+  children,
   ...rest
-}: MapChartProps) => {
-  const { projectionType, geoDomainKey, valueDomainKey, fill, stroke } = map;
+}) => {
+  // Validate GeoJSON data structure
+  if (geoJson && !('features' in geoJson)) {
+    throw new Error(
+      'GeoJSON must contain features so that each feature is mapped to a data item.'
+    );
+  }
+
   const { colorScale } = useColorScale();
   const { data, dimensions } = useChart();
 
-  const projectionCenter = useMemo(
-    () => calculateGeoProjectionCenter(geoJson, projectionType, dimensions),
+  const projectionViewport = useMemo(
+    () => calculateGeoProjectionViewport(geoJson, projectionType, dimensions),
     [geoJson, projectionType, dimensions]
   );
 
-  const shapeData = useMemo(() => {
+  const { projection, geoPathGenerator } = useMemo(
+    () => computeMapProjection(projectionType, projectionViewport),
+    [projectionType, projectionViewport]
+  );
+
+  const mapData = useMemo(() => {
     return scaleGeoFeatureData(
       data,
       geoJson?.features || [],
@@ -41,18 +56,13 @@ export const Map: React.FC<MapChartProps> = ({
   }, [data, geoJson?.features, geoDomainKey, colorScale.scale]);
 
   return (
-    <g {...rest} className="ez-map">
-      {shapeData.map((shapeDatum, idx) => {
-        return (
-          <MapPath
-            key={idx}
-            shapeDatum={shapeDatum}
-            projectionType={projectionType}
-            projectionCenter={projectionCenter}
-            stroke={stroke}
-          />
-        );
-      })}
-    </g>
+    <MapContext.Provider value={{ projection, geoPathGenerator, mapData }}>
+      <g className="ez-map" {...rest}>
+        {mapData.map((shapeDatum, idx) => {
+          return <MapPath key={idx} shapeDatum={shapeDatum} stroke={stroke} />;
+        })}
+      </g>
+      {children}
+    </MapContext.Provider>
   );
 };

--- a/packages/ez-react/src/components/Map.tsx
+++ b/packages/ez-react/src/components/Map.tsx
@@ -38,7 +38,7 @@ export const Map: React.FC<MapProps> = ({
     [geoJson, projectionType, dimensions]
   );
 
-  const { projection, geoPathGenerator } = useMemo(
+  const projection = useMemo(
     () => computeMapProjection(projectionType, projectionViewport),
     [projectionType, projectionViewport]
   );
@@ -49,6 +49,7 @@ export const Map: React.FC<MapProps> = ({
       geoJson?.features || [],
       geoDomainKey,
       valueDomainKey,
+      projection,
       colorScale,
       fill
     );
@@ -56,7 +57,7 @@ export const Map: React.FC<MapProps> = ({
   }, [data, geoJson?.features, geoDomainKey, colorScale.scale]);
 
   return (
-    <MapContext.Provider value={{ projection, geoPathGenerator, mapData }}>
+    <MapContext.Provider value={{ projection, mapData }}>
       <g className="ez-map" {...rest}>
         {mapData.map((shapeDatum, idx) => {
           return <MapPath key={idx} shapeDatum={shapeDatum} stroke={stroke} />;

--- a/packages/ez-react/src/components/MapBubbles.tsx
+++ b/packages/ez-react/src/components/MapBubbles.tsx
@@ -27,20 +27,20 @@ export const MapBubbles: FC<MapBubblesProps> = ({
 }) => {
   const { data } = useChart();
   const { sqrtScale: rScale } = useSqrtScale();
-  const { geoPathGenerator, mapData } = useMap();
+  const { projection, mapData } = useMap();
   const { colorScale } = useColorScale();
 
   const shapeData = useMemo(() => {
     return scaleMapBubbleData(
       data,
       mapData,
-      geoPathGenerator,
+      projection,
       rDomainKey,
       rScale,
       colorScale
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [data, geoPathGenerator, rDomainKey, rScale]);
+  }, [data, projection, rDomainKey, rScale]);
 
   if (scopedSlots && scopedSlots.default) {
     return (

--- a/packages/ez-react/src/components/MapBubbles.tsx
+++ b/packages/ez-react/src/components/MapBubbles.tsx
@@ -1,70 +1,64 @@
 import React, { FC, useMemo } from 'react';
-import { scaleBubbleData } from 'eazychart-core/src';
+import { scaleMapBubbleData } from 'eazychart-core/src';
 import { PointDatum } from 'eazychart-core/src/types';
 import { useChart } from '@/lib/use-chart';
-import { PointsProps } from '@/components/Points';
 import { Bubble } from '@/components/shapes/Bubble';
-import { useCartesianScales } from './scales/CartesianScale';
-import { useLinearScale } from './scales/LinearScale';
+import { useSqrtScale } from './scales/SqrtScale';
+import { useMap } from '@/lib/use-map';
+import { useColorScale } from './scales/ColorScale';
 
-export interface BubblesProps extends PointsProps {
+export interface MapBubblesProps {
   rDomainKey: string;
-  fill?: string;
+  stroke?: string;
+  strokeWidth?: number;
+  opacity?: number;
   scopedSlots?: {
     default: ({ shapeData }: { shapeData: PointDatum[] }) => React.ReactChild;
   };
 }
 
-export const Bubbles: FC<BubblesProps> = ({
-  xDomainKey,
-  yDomainKey,
+export const MapBubbles: FC<MapBubblesProps> = ({
   rDomainKey,
-  fill,
+  stroke,
+  strokeWidth,
   opacity,
   scopedSlots,
   ...rest
 }) => {
   const { data } = useChart();
-  const { xScale, yScale } = useCartesianScales();
-  const { linearScale: rScale } = useLinearScale();
+  const { sqrtScale: rScale } = useSqrtScale();
+  const { geoPathGenerator, mapData } = useMap();
+  const { colorScale } = useColorScale();
 
   const shapeData = useMemo(() => {
-    return scaleBubbleData(
+    return scaleMapBubbleData(
       data,
-      xDomainKey,
-      yDomainKey,
+      mapData,
+      geoPathGenerator,
       rDomainKey,
-      xScale,
-      yScale,
-      rScale
+      rScale,
+      colorScale
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    data,
-    xDomainKey,
-    yDomainKey,
-    rDomainKey,
-    xScale.scale,
-    yScale.scale,
-    rScale,
-  ]);
+  }, [data, geoPathGenerator, rDomainKey, rScale]);
 
   if (scopedSlots && scopedSlots.default) {
     return (
-      <g className="ez-bubbles" {...rest}>
+      <g className="ez-map-bubbles" {...rest}>
         {scopedSlots.default({ shapeData })}
       </g>
     );
   }
 
   return (
-    <g className="ez-bubbles" {...rest}>
+    <g className="ez-map-bubbles" {...rest}>
       {shapeData.map((shapeDatum) => {
         return (
           <Bubble
             shapeDatum={shapeDatum}
             key={shapeDatum.id}
-            fill={fill}
+            stroke={stroke}
+            strokeWidth={strokeWidth}
             opacity={opacity}
           />
         );

--- a/packages/ez-react/src/components/Points.tsx
+++ b/packages/ez-react/src/components/Points.tsx
@@ -52,7 +52,7 @@ export const Points: FC<PointsProps> = ({
 
   if (scopedSlots && scopedSlots.default) {
     return (
-      <g className="ez-points">
+      <g className="ez-points" {...rest}>
         {scopedSlots.default({
           shapeData,
           scales: { xScale, yScale },

--- a/packages/ez-react/src/components/scales/SqrtScale.tsx
+++ b/packages/ez-react/src/components/scales/SqrtScale.tsx
@@ -1,0 +1,50 @@
+import React, {
+  createContext,
+  FC,
+  useContext,
+  useEffect,
+  useMemo,
+} from 'react';
+import { useChart } from '@/lib/use-chart';
+import { ScaleSqrt } from 'eazychart-core/src';
+import { ScaleSqrtDefinition } from 'eazychart-core/src/types';
+import { Fragment } from '@/lib/Fragment';
+
+const SqrtScaleContext = createContext<{
+  sqrtScale: ScaleSqrt;
+}>({
+  sqrtScale: new ScaleSqrt(),
+});
+
+export const useSqrtScale = () => {
+  return useContext(SqrtScaleContext);
+};
+
+export const SqrtScale: FC<
+  ScaleSqrtDefinition & { children: React.ReactNode; isWrapped?: boolean }
+> = ({ children, isWrapped = true, ...definition }) => {
+  const { data, dimensions } = useChart();
+
+  const sqrtScale = useMemo<ScaleSqrt>(() => {
+    const scale = new ScaleSqrt(definition);
+    scale.computeScale(dimensions, data);
+    return scale;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [definition]);
+
+  useEffect(() => {
+    sqrtScale.computeScale(dimensions, data);
+  }, [dimensions, data, sqrtScale]);
+
+  return (
+    <SqrtScaleContext.Provider value={{ sqrtScale }}>
+      {isWrapped ? (
+        <Fragment type="g" name="sqrt-scale">
+          {children}
+        </Fragment>
+      ) : (
+        children
+      )}
+    </SqrtScaleContext.Provider>
+  );
+};

--- a/packages/ez-react/src/components/shapes/MapPath.tsx
+++ b/packages/ez-react/src/components/shapes/MapPath.tsx
@@ -1,26 +1,17 @@
 import React, { FC, MouseEventHandler, SVGAttributes, useMemo } from 'react';
-import {
-  GeoProjection,
-  GeoProjectionType,
-  GeoProjectionCenter,
-  GeoFeatureDatum,
-} from 'eazychart-core/src/types';
-import { defaultColor, generateGeoFeaturePath } from 'eazychart-core/src';
+import { GeoFeatureDatum } from 'eazychart-core/src/types';
+import { defaultColor } from 'eazychart-core/src';
 import { useAnimation } from '@/lib/use-animation';
 import { useChart } from '@/lib/use-chart';
 import { useTooltip } from '../addons/tooltip/use-tooltip';
+import { useMap } from '@/lib/use-map';
 
 export interface MapPathProps extends SVGAttributes<SVGPathElement> {
   shapeDatum: GeoFeatureDatum;
-  projectionType?: GeoProjectionType;
-  projection?: GeoProjection;
-  projectionCenter: GeoProjectionCenter;
 }
 
 export const MapPath: FC<MapPathProps> = ({
   shapeDatum,
-  projectionType = 'geoMercator',
-  projectionCenter,
   stroke = defaultColor,
   fill = defaultColor,
   strokeWidth = 1,
@@ -28,9 +19,10 @@ export const MapPath: FC<MapPathProps> = ({
 }) => {
   const { showTooltip, hideTooltip, moveTooltip } = useTooltip();
   const { animationOptions } = useChart();
+  const { geoPathGenerator } = useMap();
   const dataPath = useMemo(
-    () => generateGeoFeaturePath(shapeDatum, projectionType, projectionCenter),
-    [shapeDatum, projectionType, projectionCenter]
+    () => geoPathGenerator(shapeDatum.feature),
+    [geoPathGenerator, shapeDatum.feature]
   );
 
   const currentData = useAnimation(dataPath || '', '', animationOptions) || '';

--- a/packages/ez-react/src/components/shapes/MapPath.tsx
+++ b/packages/ez-react/src/components/shapes/MapPath.tsx
@@ -1,6 +1,6 @@
 import React, { FC, MouseEventHandler, SVGAttributes, useMemo } from 'react';
 import { GeoFeatureDatum } from 'eazychart-core/src/types';
-import { defaultColor } from 'eazychart-core/src';
+import { defaultColor, getGeoPathByProjection } from 'eazychart-core/src';
 import { useAnimation } from '@/lib/use-animation';
 import { useChart } from '@/lib/use-chart';
 import { useTooltip } from '../addons/tooltip/use-tooltip';
@@ -19,11 +19,11 @@ export const MapPath: FC<MapPathProps> = ({
 }) => {
   const { showTooltip, hideTooltip, moveTooltip } = useTooltip();
   const { animationOptions } = useChart();
-  const { geoPathGenerator } = useMap();
-  const dataPath = useMemo(
-    () => geoPathGenerator(shapeDatum.feature),
-    [geoPathGenerator, shapeDatum.feature]
-  );
+  const { projection } = useMap();
+  const dataPath = useMemo(() => {
+    const geoPathGenerator = getGeoPathByProjection(projection);
+    return geoPathGenerator(shapeDatum.feature);
+  }, [projection, shapeDatum.feature]);
 
   const currentData = useAnimation(dataPath || '', '', animationOptions) || '';
 

--- a/packages/ez-react/src/index.ts
+++ b/packages/ez-react/src/index.ts
@@ -32,6 +32,10 @@ export {
 } from '@/recipes/line/MultiLineChart';
 export { MapChart, MapChartProps } from '@/recipes/map/MapChart';
 export {
+  BubbleMapChart,
+  BubbleMapChartProps,
+} from '@/recipes/map/BubbleMapChart';
+export {
   ResponsiveChartContainer,
   ResponsiveChartContainerProps,
 } from '@/components/ResponsiveChartContainer';

--- a/packages/ez-react/src/lib/use-map.ts
+++ b/packages/ez-react/src/lib/use-map.ts
@@ -1,0 +1,8 @@
+import { createContext, useContext } from 'react';
+import { defaultMapContext } from 'eazychart-core/src';
+
+export const MapContext = createContext(defaultMapContext);
+
+export const useMap = () => {
+  return useContext(MapContext);
+};

--- a/packages/ez-react/src/recipes/map/BubbleMapChart.stories.tsx
+++ b/packages/ez-react/src/recipes/map/BubbleMapChart.stories.tsx
@@ -6,7 +6,6 @@ import {
   animationOptions,
   mapGeoJson,
 } from 'eazychart-dev/storybook/data';
-import { MapChartProps, MapChart } from '@/recipes/map/MapChart';
 import { GeoProjectionType } from 'eazychart-core/src/utils/types';
 import {
   BASE_CHART_ARG_TYPES,
@@ -14,16 +13,18 @@ import {
   getArgTypesByProp,
 } from 'eazychart-dev/storybook/utils';
 import { ChartWrapper, buildTemplate } from '../../lib/storybook-utils';
+import { BubbleMapChart, BubbleMapChartProps } from './BubbleMapChart';
 
 const mapChartArgs = {
   ...BASE_CHART_ARG_TYPES,
   ...getArgTypesByProp('map'),
   ...getArgTypesByProp('geoJson'),
+  ...getArgTypesByProp('bubble'),
 };
 const meta: Meta = {
   id: '11',
-  title: 'React/Map Chart',
-  component: MapChart,
+  title: 'React/Map Chart/BubbleMap',
+  component: BubbleMapChart,
   parameters: {
     controls: { expanded: true },
   },
@@ -32,11 +33,11 @@ const meta: Meta = {
 
 export default meta;
 
-const DefaultTemplate: Story<MapChartProps> = buildTemplate(
-  (args: MapChartProps) => {
+const BubbleTemplate: Story<BubbleMapChartProps> = buildTemplate(
+  (args: BubbleMapChartProps) => {
     return (
       <ChartWrapper>
-        <MapChart {...args} />
+        <BubbleMapChart {...args} />
       </ChartWrapper>
     );
   }
@@ -44,22 +45,30 @@ const DefaultTemplate: Story<MapChartProps> = buildTemplate(
 
 // By passing using the Args format for exported stories, you can control the props for a component for reuse in a test
 // https://storybook.js.org/docs/react/workflows/unit-testing
-export const Default = DefaultTemplate.bind({});
-
+export const BubbleMap = BubbleTemplate.bind({});
 const defaultArguments = flattenArgs({
   map: {
     geoDomainKey: 'admin',
     valueDomainKey: 'value',
     projectionType: 'geoMercator' as GeoProjectionType,
     stroke: 'black',
-    fill: 'black',
+    fill: 'white',
   },
   dimensions: { width: 800, height: 600 },
   padding,
   animationOptions,
   colors: ['white', 'pink', 'red'],
+  bubble: {
+    domainKey: 'rValue',
+    minRadius: 5,
+    maxRadius: 20,
+    opacity: 0.5,
+    stroke: 'black',
+    strokeWidth: 1,
+    colors: ['green', 'yellowgreen', 'yellow'],
+  },
   geoJson: mapGeoJson,
   data: mapData,
 });
 
-Default.args = defaultArguments;
+BubbleMap.args = defaultArguments;

--- a/packages/ez-react/src/recipes/map/BubbleMapChart.tsx
+++ b/packages/ez-react/src/recipes/map/BubbleMapChart.tsx
@@ -1,0 +1,88 @@
+import React, { FC } from 'react';
+import { BubbleConfig } from 'eazychart-core/src/types';
+import { Map } from '@/components/Map';
+import { Tooltip } from '@/components/addons/tooltip/Tooltip';
+import { Chart } from '@/components/Chart';
+import { ColorScale } from '@/components/scales/ColorScale';
+import { MapChartProps } from './MapChart';
+import { SqrtScale } from '@/components/scales/SqrtScale';
+import { MapBubbles } from '@/components/MapBubbles';
+
+export interface BubbleMapChartProps extends MapChartProps {
+  bubble: BubbleConfig;
+}
+
+export const BubbleMapChart: FC<BubbleMapChartProps> = ({
+  data,
+  geoJson,
+  colors = ['white', 'pink', 'red'],
+  map = {
+    geoDomainKey: 'geo_code',
+    valueDomainKey: 'value',
+    projectionType: 'geoMercator',
+    stroke: 'white',
+    fill: 'black',
+  },
+  bubble = {
+    domainKey: 'rValue',
+    minRadius: 1,
+    maxRadius: 100,
+    opacity: 0.5,
+    stroke: 'black',
+    strokeWidth: 1,
+    colors: ['green', 'yellowgreen', 'yellow'],
+  },
+  animationOptions = {
+    easing: 'easeBack',
+    duration: 400,
+    delay: 0,
+  },
+  padding = {
+    left: 100,
+    bottom: 100,
+    right: 100,
+    top: 100,
+  },
+  dimensions = {},
+  scopedSlots = {
+    // @todo : support Legend
+    // LegendComponent: Legend,
+    TooltipComponent: Tooltip,
+  },
+}) => {
+  return (
+    <Chart
+      dimensions={dimensions}
+      rawData={data}
+      padding={padding}
+      animationOptions={animationOptions}
+      scopedSlots={scopedSlots}
+    >
+      <ColorScale
+        type={'quantile'}
+        domainKey={map.valueDomainKey}
+        range={colors}
+      >
+        <Map map={map} geoJson={geoJson}>
+          <ColorScale
+            type={'quantile'}
+            domainKey={bubble.domainKey}
+            range={bubble.colors}
+          >
+            <SqrtScale
+              domainKey={bubble.domainKey}
+              range={[bubble.minRadius, bubble.maxRadius]}
+            >
+              <MapBubbles
+                rDomainKey={bubble.domainKey}
+                stroke={bubble.stroke}
+                strokeWidth={bubble.strokeWidth}
+                opacity={bubble.opacity}
+              />
+            </SqrtScale>
+          </ColorScale>
+        </Map>
+      </ColorScale>
+    </Chart>
+  );
+};

--- a/packages/ez-react/src/recipes/map/MapChart.tsx
+++ b/packages/ez-react/src/recipes/map/MapChart.tsx
@@ -56,12 +56,6 @@ export const MapChart: FC<MapChartProps> = ({
     TooltipComponent: Tooltip,
   },
 }) => {
-  if (geoJson && !('features' in geoJson)) {
-    throw new Error(
-      'GeoJSON must contain features so that each feature is mapped to a data item.'
-    );
-  }
-
   return (
     <Chart
       dimensions={dimensions}

--- a/packages/ez-react/tests/unit/components/Map.spec.tsx
+++ b/packages/ez-react/tests/unit/components/Map.spec.tsx
@@ -1,40 +1,46 @@
 import React from 'react';
 import { act, render, RenderResult, waitFor } from '@testing-library/react';
-import { Chart } from '@/components/Chart';
 import {
   dimensions,
   mapFeatureData,
   rawData,
 } from 'eazychart-core/src/sample-data';
-import { baseChartProps } from 'tests/common';
-import 'tests/mocks/ResizeObserver';
+// import 'tests/mocks/ResizeObserver';
 import { Map } from '@/components/Map';
+import { useChart } from '@/lib/use-chart';
+
+jest.mock('@/lib/use-chart');
 
 describe('Map', () => {
+  beforeEach(() => {
+    (useChart as jest.Mock).mockImplementation(() => ({
+      data: rawData,
+      dimensions,
+      animationOptions: {
+        easing: 'easeLinear',
+        duration: 0,
+        delay: 0,
+      },
+    }));
+  });
+  afterAll(() => {
+    jest.clearAllMocks();
+  });
+
   it('renders svg areas using GeoJSON features', async () => {
     let wrapper: RenderResult;
     act(() => {
       wrapper = render(
-        <Chart
-          {...baseChartProps}
-          rawData={rawData}
-          dimensions={dimensions}
-          scopedSlots={{
-            LegendComponent: () => <>{null}</>,
-            TooltipComponent: () => <>{null}</>,
+        <Map
+          geoJson={mapFeatureData}
+          map={{
+            geoDomainKey: 'label',
+            valueDomainKey: 'value',
+            projectionType: 'geoMercator',
+            fill: 'blue',
+            stroke: 'red',
           }}
-        >
-          <Map
-            geoJson={mapFeatureData}
-            map={{
-              geoDomainKey: 'label',
-              valueDomainKey: 'value',
-              projectionType: 'geoMercator',
-              fill: 'blue',
-              stroke: 'red',
-            }}
-          />
-        </Chart>
+        />
       );
     });
 

--- a/packages/ez-react/tests/unit/components/shapes/MapPath.spec.tsx
+++ b/packages/ez-react/tests/unit/components/shapes/MapPath.spec.tsx
@@ -7,18 +7,28 @@ import 'tests/mocks/ResizeObserver';
 import { MapPath } from '@/components/shapes/MapPath';
 import { GeoFeatureDatum } from 'eazychart-core/src/types';
 import {
-  calculateGeoProjectionCenter,
+  calculateGeoProjectionViewport,
+  computeMapProjection,
   defaultChartDimensions,
 } from 'eazychart-core/src';
 
+jest.mock('@/lib/use-map', () => {
+  const projectionViewport = calculateGeoProjectionViewport(
+    { type: 'FeatureCollection', features: [geoFeatureA] },
+    'geoMercator',
+    defaultChartDimensions
+  );
+
+  return jest.fn(() => computeMapProjection('geoMercator', projectionViewport));
+});
+
 describe('MapPath', () => {
+  afterAll(() => {
+    jest.clearAllMocks();
+  });
+
   it('renders an svg path given a GeoJSON feature', async () => {
     let wrapper: RenderResult;
-    const projectionCenter = calculateGeoProjectionCenter(
-      { type: 'FeatureCollection', features: [geoFeatureA] },
-      'geoMercator',
-      defaultChartDimensions
-    );
     await act(async () => {
       wrapper = renderSVG(
         <Chart
@@ -30,9 +40,8 @@ describe('MapPath', () => {
         >
           <MapPath
             shapeDatum={
-              { id: '1', color: 'red', ...geoFeatureA } as GeoFeatureDatum
+              { id: '1', color: 'red', feature: geoFeatureA } as GeoFeatureDatum
             }
-            projectionCenter={projectionCenter}
           />
         </Chart>
       );

--- a/packages/ez-react/tests/unit/components/shapes/MapPath.spec.tsx
+++ b/packages/ez-react/tests/unit/components/shapes/MapPath.spec.tsx
@@ -6,23 +6,33 @@ import { baseChartProps, renderSVG } from 'tests/common';
 import 'tests/mocks/ResizeObserver';
 import { MapPath } from '@/components/shapes/MapPath';
 import { GeoFeatureDatum } from 'eazychart-core/src/types';
+import { useMap } from '@/lib/use-map';
+
 import {
   calculateGeoProjectionViewport,
   computeMapProjection,
   defaultChartDimensions,
 } from 'eazychart-core/src';
 
-jest.mock('@/lib/use-map', () => {
-  const projectionViewport = calculateGeoProjectionViewport(
-    { type: 'FeatureCollection', features: [geoFeatureA] },
-    'geoMercator',
-    defaultChartDimensions
-  );
-
-  return jest.fn(() => computeMapProjection('geoMercator', projectionViewport));
-});
+jest.mock('@/lib/use-map');
 
 describe('MapPath', () => {
+  beforeEach(() => {
+    (useMap as jest.Mock).mockImplementation(() => {
+      const projectionViewport = calculateGeoProjectionViewport(
+        { type: 'FeatureCollection', features: [geoFeatureA] },
+        'geoMercator',
+        defaultChartDimensions
+      );
+
+      const projection = computeMapProjection(
+        'geoMercator',
+        projectionViewport
+      );
+
+      return { projection };
+    });
+  });
   afterAll(() => {
     jest.clearAllMocks();
   });

--- a/packages/ez-vue/src/components/MapBubbles.tsx
+++ b/packages/ez-vue/src/components/MapBubbles.tsx
@@ -1,0 +1,84 @@
+import Vue from 'vue';
+import Component from 'vue-class-component';
+import { AnyScale, ChartContext, MapContext } from 'eazychart-core/src/types';
+import { InjectReactive, Prop } from 'vue-property-decorator';
+import { ScaleSqrt, scaleMapBubbleData } from 'eazychart-core/src';
+import Bubble from './shapes/Bubble';
+
+@Component({ components: { Bubble } })
+export default class Bubbles extends Vue {
+  @InjectReactive('chart')
+  private chart!: ChartContext;
+
+  @InjectReactive('mapContext')
+  private mapContext!: MapContext;
+
+  @InjectReactive('colorScale')
+  private colorScale!: AnyScale;
+
+  @InjectReactive('sqrtScale')
+  private rScale!: ScaleSqrt;
+
+  @Prop({
+    type: Number,
+    required: true,
+  })
+  private readonly strokeWidth!: number;
+
+  @Prop({
+    type: Number,
+    required: true,
+  })
+  private readonly opacity!: number;
+
+  @Prop({
+    type: String,
+    required: true,
+  })
+  private readonly stroke!: string;
+
+  @Prop({
+    type: String,
+    required: true,
+  })
+  private readonly rDomainKey!: string;
+
+  get shapeData() {
+    const { chart, mapContext, colorScale } = this;
+    const { mapData, projection } = mapContext;
+    return scaleMapBubbleData(
+      chart.data,
+      mapData,
+      projection,
+      this.rDomainKey,
+      this.rScale,
+      colorScale,
+    );
+  }
+
+  render() {
+    const {
+      shapeData, $scopedSlots, stroke, strokeWidth, opacity,
+    } = this;
+
+    if ($scopedSlots.default) {
+      return (
+        <g class="ez-map-bubbles">{$scopedSlots.default({ shapeData })}</g>
+      );
+    }
+
+    return (
+      <g class="ez-map-bubbles">
+        {shapeData.map((shapeDatum) => (
+          <Bubble
+            shapeDatum={shapeDatum}
+            key={shapeDatum.id}
+            stroke={stroke}
+            strokeWidth={strokeWidth}
+            opacity={opacity}
+          />
+        ))}
+      </g>
+    );
+  }
+}

--- a/packages/ez-vue/src/components/scales/SqrtScale.tsx
+++ b/packages/ez-vue/src/components/scales/SqrtScale.tsx
@@ -1,0 +1,56 @@
+import Vue, { PropType } from 'vue';
+import Component from 'vue-class-component';
+import {
+  InjectReactive,
+  Prop,
+  ProvideReactive,
+  Watch,
+} from 'vue-property-decorator';
+import { ChartContext, ScaleSqrtDefinition } from 'eazychart-core/src/types';
+import { ScaleSqrt } from 'eazychart-core/src';
+import Fragment from '@/lib/Fragment';
+
+@Component
+export default class SqrtScale extends Vue {
+  @InjectReactive('chart')
+  private chart!: ChartContext;
+
+  @ProvideReactive('sqrtScale')
+  private sqrtScale = new ScaleSqrt();
+
+  @Prop({
+    type: Object as PropType<ScaleSqrtDefinition>,
+    required: true,
+  })
+  private readonly definition!: ScaleSqrtDefinition;
+
+  mounted() {
+    this.defineScale();
+  }
+
+  @Watch('chart.dimensions')
+  @Watch('chart.data')
+  recomputeScale() {
+    const { dimensions, data } = this.chart;
+    this.sqrtScale.computeScale(dimensions, data);
+  }
+
+  @Watch('chart.definition')
+  defineScale() {
+    const { definition } = this;
+    const { dimensions, data } = this.chart;
+    this.sqrtScale = new ScaleSqrt(definition);
+    this.sqrtScale.computeScale(dimensions, data);
+  }
+
+  render() {
+    const DefaultSlot = this.$scopedSlots.default
+      ? this.$scopedSlots.default({})
+      : null;
+    return (
+      <Fragment type="g" name="sqrt-scale">
+        {DefaultSlot}
+      </Fragment>
+    );
+  }
+}

--- a/packages/ez-vue/src/components/shapes/MapPath.tsx
+++ b/packages/ez-vue/src/components/shapes/MapPath.tsx
@@ -79,7 +79,7 @@ export default class MapPath extends mixins(AnimationMixin) {
   get animationArguments() {
     const { shapeDatum, projectionType, projectionCenter } = this;
     const path = generateGeoFeaturePath(
-      shapeDatum,
+      shapeDatum.feature,
       projectionType,
       projectionCenter,
     );

--- a/packages/ez-vue/src/recipes/map/BubbleMapChart.stories.tsx
+++ b/packages/ez-vue/src/recipes/map/BubbleMapChart.stories.tsx
@@ -1,0 +1,82 @@
+import { Meta, Story } from '@storybook/vue';
+import {
+  animationOptions,
+  mapData,
+  mapGeoJson,
+  padding,
+} from 'eazychart-dev/storybook/data';
+import {
+  BASE_CHART_ARG_TYPES,
+  flattenArgs,
+  getArgTypesByProp,
+} from 'eazychart-dev/storybook/utils';
+import { GeoProjectionType } from 'eazychart-core/src/types';
+import { ChartWrapper, buildTemplate } from '@/lib/storybook-utils';
+import BubbleMapChart from './BubbleMapChart';
+
+const mapChartArgs = {
+  ...BASE_CHART_ARG_TYPES,
+  ...getArgTypesByProp('map'),
+  ...getArgTypesByProp('geoJson'),
+  ...getArgTypesByProp('bubble'),
+};
+
+const meta: Meta = {
+  title: 'Vue/Map Chart/BubbleMap',
+  component: BubbleMapChart,
+  parameters: {
+    controls: { expanded: true },
+  },
+  argTypes: mapChartArgs,
+};
+
+export default meta;
+
+type BubbleMapChartProps = InstanceType<typeof BubbleMapChart>['$props'];
+
+const DefaultTemplate: Story = buildTemplate((args: BubbleMapChartProps) => ({
+  title: 'BubbleMap',
+  components: { BubbleMapChart, ChartWrapper },
+  props: {
+    allPropsFromArgs: {
+      default: () => args,
+    },
+  },
+  template: `
+    <ChartWrapper>
+      <BubbleMapChart v-bind="allPropsFromArgs" />
+    </ChartWrapper>
+  `,
+}));
+
+// By passing using the Args format for exported stories,
+// you can control the props for a component for reuse in a test
+// https://storybook.js.org/docs/vue/workflows/unit-testing
+export const BubbleMap = DefaultTemplate.bind({});
+
+const defaultArguments = flattenArgs({
+  map: {
+    geoDomainKey: 'admin',
+    valueDomainKey: 'value',
+    projectionType: 'geoMercator' as GeoProjectionType,
+    stroke: 'black',
+    fill: 'white',
+  },
+  dimensions: { width: 800, height: 600 },
+  padding,
+  animationOptions,
+  colors: ['white', 'pink', 'red'],
+  bubble: {
+    domainKey: 'rValue',
+    minRadius: 5,
+    maxRadius: 20,
+    opacity: 0.5,
+    stroke: 'black',
+    strokeWidth: 1,
+    colors: ['green', 'yellowgreen', 'yellow'],
+  },
+  geoJson: mapGeoJson,
+  data: mapData,
+});
+
+BubbleMap.args = defaultArguments;

--- a/packages/ez-vue/src/recipes/map/BubbleMapChart.tsx
+++ b/packages/ez-vue/src/recipes/map/BubbleMapChart.tsx
@@ -1,0 +1,179 @@
+import Vue, { PropType } from 'vue';
+import Component from 'vue-class-component';
+import {
+  GeoJsonData,
+  ChartPadding,
+  Dimensions,
+  MapConfig,
+  AnimationOptions,
+  RawData,
+  BubbleConfig,
+} from 'eazychart-core/src/types';
+import { Prop } from 'vue-property-decorator';
+import Chart from '@/components/Chart';
+import Axis from '@/components/scales/Axis';
+import Legend from '@/components/addons/legend/Legend';
+import Tooltip from '@/components/addons/tooltip/Tooltip';
+import Grid from '@/components/scales/grid/Grid';
+import Map from '@/components/Map';
+import ColorScale from '@/components/scales/ColorScale';
+import MapBubbles from '@/components/MapBubbles';
+import SqrtScale from '@/components/scales/SqrtScale';
+
+@Component({
+  components: {
+    Chart,
+    Grid,
+    Map,
+    MapBubbles,
+    Axis,
+    Legend,
+    Tooltip,
+  },
+})
+export default class BubbleMapChart extends Vue {
+  @Prop({
+    type: Object as PropType<Dimensions>,
+    default() {
+      return {};
+    },
+  })
+  private readonly dimensions!: Partial<Dimensions>;
+
+  @Prop({
+    type: Object as PropType<BubbleConfig>,
+    default() {
+      return {
+        domainKey: 'rValue',
+        minRadius: 1,
+        maxRadius: 100,
+        opacity: 0.5,
+        stroke: 'black',
+        strokeWidth: 1,
+        colors: ['green', 'yellowgreen', 'yellow'],
+      };
+    },
+  })
+  private readonly bubble!: BubbleConfig;
+
+  @Prop({
+    type: Object as PropType<AnimationOptions>,
+    default() {
+      return {
+        easing: 'easeBack',
+        duration: 400,
+        delay: 0,
+      };
+    },
+  })
+  private readonly animationOptions!: AnimationOptions;
+
+  @Prop({
+    type: Object as PropType<ChartPadding>,
+    default() {
+      return {
+        left: 100,
+        bottom: 100,
+        right: 100,
+        top: 100,
+      };
+    },
+  })
+  private readonly padding!: Partial<ChartPadding>;
+
+  @Prop({
+    type: Object as PropType<MapConfig>,
+    default: () => ({
+      geoDomainKey: 'geo_code',
+      valueDomainKey: 'value',
+      projectionType: 'geoMercator',
+      stroke: 'white',
+      fill: 'black',
+    }),
+  })
+  private readonly map!: MapConfig;
+
+  @Prop({
+    type: Object as PropType<GeoJsonData>,
+  })
+  private readonly geoJson!: GeoJsonData;
+
+  @Prop({
+    type: Array,
+    default: () => ['white', 'pink', 'red'],
+  })
+  private readonly colors!: string[];
+
+  @Prop({
+    type: Array as PropType<RawData>,
+  })
+  private readonly data!: RawData;
+
+  render() {
+    const {
+      geoJson,
+      map,
+      padding,
+      animationOptions,
+      $scopedSlots,
+      dimensions,
+      data,
+      colors,
+      bubble,
+    } = this;
+
+    if (geoJson && !('features' in geoJson)) {
+      throw new Error(
+        'GeoJSON must contain features so that each feature is mapped to a data item.',
+      );
+    }
+
+    return (
+      <Chart
+        dimensions={dimensions}
+        padding={padding}
+        animationOptions={animationOptions}
+        scopedSlots={$scopedSlots}
+        rawData={data}
+      >
+        <ColorScale
+          type={'quantile'}
+          definition={{
+            domainKey: map.valueDomainKey,
+            range: colors,
+          }}
+        >
+          <Map
+            map={map}
+            geoJson={geoJson}
+            scopedSlots={{
+              default: () => (
+                <ColorScale
+                  type={'quantile'}
+                  definition={{
+                    domainKey: bubble.domainKey,
+                    range: bubble.colors,
+                  }}
+                >
+                  <SqrtScale
+                    definition={{
+                      domainKey: bubble.domainKey,
+                      range: [bubble.minRadius, bubble.maxRadius],
+                    }}
+                  >
+                    <MapBubbles
+                      rDomainKey={bubble.domainKey}
+                      stroke={bubble.stroke}
+                      strokeWidth={bubble.strokeWidth}
+                      opacity={bubble.opacity}
+                    />
+                  </SqrtScale>
+                </ColorScale>
+              ),
+            }}
+          ></Map>
+        </ColorScale>
+      </Chart>
+    );
+  }
+}

--- a/packages/ez-vue/src/recipes/map/MapChart.stories.tsx
+++ b/packages/ez-vue/src/recipes/map/MapChart.stories.tsx
@@ -2,6 +2,7 @@ import { Meta, Story } from '@storybook/vue';
 import {
   animationOptions,
   mapData,
+  mapGeoJson,
   padding,
 } from 'eazychart-dev/storybook/data';
 import {
@@ -9,10 +10,7 @@ import {
   flattenArgs,
   getArgTypesByProp,
 } from 'eazychart-dev/storybook/utils';
-import {
-  GeoFeatureCollection,
-  GeoProjectionType,
-} from 'eazychart-core/src/types';
+import { GeoProjectionType } from 'eazychart-core/src/types';
 import MapChart from '@/recipes/map/MapChart';
 import { ChartWrapper, buildTemplate } from '@/lib/storybook-utils';
 
@@ -67,11 +65,8 @@ const defaultArguments = flattenArgs({
   padding,
   animationOptions,
   colors: ['white', 'pink', 'red'],
-  geoJson: mapData,
-  data: (mapData as GeoFeatureCollection).features.map((feature, idx) => ({
-    admin: feature.properties?.admin,
-    value: idx,
-  })),
+  geoJson: mapGeoJson,
+  data: mapData,
 });
 
 Default.args = defaultArguments;

--- a/packages/ez-vue/tests/unit/components/Map.spec.tsx
+++ b/packages/ez-vue/tests/unit/components/Map.spec.tsx
@@ -38,7 +38,6 @@ describe('Map', () => {
     });
 
     await Vue.nextTick();
-
     expect(wrapper.container.innerHTML).toMatchSnapshot();
   });
 });

--- a/packages/ez-vue/tests/unit/components/shapes/MapPath.spec.tsx
+++ b/packages/ez-vue/tests/unit/components/shapes/MapPath.spec.tsx
@@ -1,24 +1,23 @@
 import Vue from 'vue';
 import { render } from '@testing-library/vue';
-import {
-  dimensions,
-  geoFeatureA,
-  tooltip,
-} from 'eazychart-core/src/sample-data';
+import { geoFeatureA, tooltip } from 'eazychart-core/src/sample-data';
 import MapPath from '@/components/shapes/MapPath';
 import {
-  calculateGeoProjectionCenter,
+  calculateGeoProjectionViewport,
+  computeMapProjection,
   defaultChartDimensions,
 } from 'eazychart-core/src';
 import { GeoFeatureDatum } from 'eazychart-core/src/types';
 
 describe('MapPath', () => {
   it('renders an svg path given a GeoJSON feature', async () => {
-    const projectionCenter = calculateGeoProjectionCenter(
+    const projectionViewport = calculateGeoProjectionViewport(
       { type: 'FeatureCollection', features: [geoFeatureA] },
       'geoMercator',
       defaultChartDimensions,
     );
+    const projection = computeMapProjection('geoMercator', projectionViewport);
+
     const wrapper = render(MapPath, {
       propsData: {
         shapeDatum: {
@@ -26,7 +25,6 @@ describe('MapPath', () => {
           color: 'red',
           feature: geoFeatureA,
         } as GeoFeatureDatum,
-        projectionCenter,
       },
       provide: {
         __reactiveInject__: {
@@ -37,9 +35,9 @@ describe('MapPath', () => {
               delay: 0,
             },
           },
+          mapContext: { projection },
         },
         tooltip,
-        dimensions,
       },
     });
 

--- a/packages/ez-vue/tests/unit/components/shapes/MapPath.spec.tsx
+++ b/packages/ez-vue/tests/unit/components/shapes/MapPath.spec.tsx
@@ -24,7 +24,7 @@ describe('MapPath', () => {
         shapeDatum: {
           id: '1',
           color: 'red',
-          ...geoFeatureA,
+          feature: geoFeatureA,
         } as GeoFeatureDatum,
         projectionCenter,
       },


### PR DESCRIPTION
# Motivation

Thanks to @deathsh0ot  we finally been able in this third attempt to introduce the bubble map chart along with the existing map chart by refactoring code and optimizing the execution flow.

We came to the conclusion that map based chart is unlike any other chart and it should have it's proper mechanics. It should be able to compute projection data once and pass it the  additioinal components (bubbles for our case). That's why we decided to implement it as a context provider.

![image](https://user-images.githubusercontent.com/1827776/229350677-8fa42da7-0d81-4896-a181-e6561bce56c6.png)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] I have done the work for both react and vue
- [X] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (Storybook)
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
