### PR TITLE
fix: add missing bubble map chart export for vue

### DIFF
--- a/packages/ez-vue/index.ts
+++ b/packages/ez-vue/index.ts
@@ -14,6 +14,7 @@ import Legend from './src/components/addons/legend/Legend';
 import Tooltip from './src/components/addons/tooltip/Tooltip';
 import MultiLineChart from './src/recipes/line/MultiLineChart';
 import MapChart from './src/recipes/map/MapChart';
+import BubbleMapChart from './src/recipes/map/BubbleMapChart';
 import ResponsiveChartContainer from './src/components/ResponsiveChartContainer';
 
 export {
@@ -33,5 +34,6 @@ export {
   Tooltip,
   MultiLineChart,
   MapChart,
+  BubbleMapChart,
   ResponsiveChartContainer,
 };


### PR DESCRIPTION
# Motivation


Add missing bubble map chart export for vue

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I have done the work for both react and vue
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (Storybook)
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
