### PR TITLE
fix: now types are exported by the library

### DIFF
--- a/packages/ez-core/src/index.ts
+++ b/packages/ez-core/src/index.ts
@@ -37,3 +37,5 @@ export {
 export { default as Axis } from './axis';
 
 export * from './utils';
+
+export * from './types';


### PR DESCRIPTION
# Motivation

This PR fixes the issue of being unable to import types from the ez-core package

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I have done the work for both react and vue
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (Storybook)
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
