### PR TITLE
fix: discontinued data for line charts

### DIFF
--- a/packages/ez-core/src/utils/scale.ts
+++ b/packages/ez-core/src/utils/scale.ts
@@ -26,7 +26,7 @@ export const scaleDatumValue = <T = string | number>(
 ) => {
   if (domainKey in datum) {
     const value = datum[domainKey] as T;
-    const scaleValue = AnyScale.scale(value as NumberLike) || 0;
+    const scaleValue = AnyScale.scale(value as NumberLike);
     return scaleValue;
   }
   throw new Error('Domain key does not exist in the supplied data');
@@ -143,9 +143,11 @@ export const scalePointData = (
   xScale: AnyScale,
   yScale: AnyScale
 ): PointDatum[] => {
-  return data.map(datum => {
-    return scalePointDatum(datum, xDomainKey, yDomainKey, xScale, yScale);
-  });
+  return data
+    .map(datum => {
+      return scalePointDatum(datum, xDomainKey, yDomainKey, xScale, yScale);
+    })
+    .filter(d => typeof d.x !== undefined && typeof d.y !== 'undefined');
 };
 
 export const scaleBubbleData = (


### PR DESCRIPTION
# Motivation

For line chart, data value could be missing (null) for a specfic range, what makes the point and lines get "0" on the Y Axis. This PR fixes that by allowing null values (scaled to undefined)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have done the work for both react and vue
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (Storybook)
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
