### PR TITLE
fix: quantile scale

### DIFF
--- a/packages/ez-core/src/scales/ScaleQuantile.ts
+++ b/packages/ez-core/src/scales/ScaleQuantile.ts
@@ -43,9 +43,10 @@ class ScaleQuantile
     data: Array<any>,
     fallback: ArrayOfTwoOrMoreNumbers = [] as unknown as ArrayOfTwoOrMoreNumbers
   ): ArrayOfTwoOrMoreNumbers => {
-    if (definition.domain) return definition.domain;
-    if (Number.isFinite(definition.min) && Number.isFinite(definition.max))
-      return [definition.min, definition.max] as [number, number];
+    if (definition.domain) {
+      return definition.domain;
+    }
+
     if (definition.domainKey && data.length) {
       const values: Array<number> = data.map((d) => {
         if (definition.domainKey && definition.domainKey in d) {
@@ -55,14 +56,16 @@ class ScaleQuantile
         return (
           Object.values(d).find((value: unknown) => Number.isFinite(value)) || 0
         );
-      });
+      }).sort((a, b) => a - b);
+
       const min = Number.isFinite(definition.min)
         ? (definition.min as number)
         : Math.min(definition.softMin, ...values) - definition.minPadding;
       const max = Number.isFinite(definition.max)
         ? (definition.max as number)
         : Math.max(definition.softMax, ...values) + definition.maxPadding;
-      return [min, max];
+      
+      return [min, ...values.slice(1, -1), max] as unknown as ArrayOfTwoOrMoreNumbers;
     }
     return fallback;
   };
@@ -113,7 +116,7 @@ class ScaleQuantile
   ): D3ScaleQuantile<NumberLike, unknown> {
     const range = this.getQuantileScaleRange(this.definition, dimensions);
     const domain = this.getQuantileScaleDomain(this.definition, data);
-
+    console.log("Range ==== ", range, domain, data.map((d) => d[this.definition.domainKey as any]))
     let scale = scaleQuantile(range).domain(domain) as D3ScaleQuantile<
       NumberLike,
       unknown

--- a/packages/ez-core/src/scales/__tests__/ScaleQuantile.test.ts
+++ b/packages/ez-core/src/scales/__tests__/ScaleQuantile.test.ts
@@ -22,8 +22,8 @@ describe('QuantileScale domain', () => {
     const quantile = new D3ScaleQuantile({
       ...{ domainKey: 'value' },
     });
-    quantile.setData([{ value: 20 }, { value: 50 }]);
-    expect(quantile.scale.domain()).toEqual([20, 50]);
+    quantile.setData([{ value: 20 }, { value: 10 }, { value: 50 }]);
+    expect(quantile.scale.domain()).toEqual([10, 20, 50]);
   });
 
   it('Resolves to 0 when it is not possible to deduce the domain from data and domainKey is provided but not valid', () => {


### PR DESCRIPTION
# Motivation

Quantile scale domain should contain all domain values not only the min and max.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have done the work for both react and vue
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (Storybook)
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
