### PR TITLE
fix: eazychart-react missing exports

### DIFF
--- a/packages/ez-react/src/components/scales/ColorScale.tsx
+++ b/packages/ez-react/src/components/scales/ColorScale.tsx
@@ -35,7 +35,7 @@ type ColorScaleQuantileProps = ScaleQuantileDefinition & {
   isWrapped?: boolean;
 };
 
-type ColorScaleProps = ColorScaleOrdinalProps | ColorScaleQuantileProps;
+export type ColorScaleProps = ColorScaleOrdinalProps | ColorScaleQuantileProps;
 
 export const ColorScale: FC<ColorScaleProps> = ({
   children,

--- a/packages/ez-react/src/components/scales/LinearScale.tsx
+++ b/packages/ez-react/src/components/scales/LinearScale.tsx
@@ -20,9 +20,16 @@ export const useLinearScale = () => {
   return useContext(LinearScaleContext);
 };
 
-export const LinearScale: FC<
-  ScaleLinearDefinition & { children: React.ReactNode; isWrapped?: boolean }
-> = ({ children, isWrapped = true, ...definition }) => {
+export type LinearScaleProps = ScaleLinearDefinition & {
+  children: React.ReactNode;
+  isWrapped?: boolean;
+};
+
+export const LinearScale: FC<LinearScaleProps> = ({
+  children,
+  isWrapped = true,
+  ...definition
+}) => {
   const { data, dimensions } = useChart();
 
   const linearScale = useMemo<ScaleLinear>(() => {

--- a/packages/ez-react/src/components/scales/SqrtScale.tsx
+++ b/packages/ez-react/src/components/scales/SqrtScale.tsx
@@ -20,9 +20,16 @@ export const useSqrtScale = () => {
   return useContext(SqrtScaleContext);
 };
 
-export const SqrtScale: FC<
-  ScaleSqrtDefinition & { children: React.ReactNode; isWrapped?: boolean }
-> = ({ children, isWrapped = true, ...definition }) => {
+export type SqrtScaleProps = ScaleSqrtDefinition & {
+  children: React.ReactNode;
+  isWrapped?: boolean;
+};
+
+export const SqrtScale: FC<SqrtScaleProps> = ({
+  children,
+  isWrapped = true,
+  ...definition
+}) => {
   const { data, dimensions } = useChart();
 
   const sqrtScale = useMemo<ScaleSqrt>(() => {

--- a/packages/ez-react/src/index.ts
+++ b/packages/ez-react/src/index.ts
@@ -1,15 +1,61 @@
+// addons
+export { Legend, LegendProps } from '@/components/addons/legend/Legend';
+export { Tooltip, TooltipProps } from '@/components/addons/tooltip/Tooltip';
+// scales
+export { Grid, GridProps } from '@/components/scales/grid/Grid';
+export { GridLines, GridLinesProps } from '@/components/scales/grid/GridLines';
+export { Axis, AxisProps } from '@/components/scales/Axis';
+export {
+  CartesianScale,
+  CartesianScaleProps,
+  useCartesianScales,
+} from '@/components/scales/CartesianScale';
+export {
+  ColorScale,
+  ColorScaleProps,
+  useColorScale,
+} from '@/components/scales/ColorScale';
+export {
+  LinearScale,
+  LinearScaleProps,
+  useLinearScale,
+} from '@/components/scales/LinearScale';
+export {
+  SqrtScale,
+  SqrtScaleProps,
+  useSqrtScale,
+} from '@/components/scales/SqrtScale';
+// shapes
+export { Arc, ArcProps } from '@/components/shapes/Arc';
+export { AreaPath, AreaPathProps } from '@/components/shapes/AreaPath';
+export { Bar, BarProps } from '@/components/shapes/Bar';
+export { Bubble, BubbleProps } from '@/components/shapes/Bubble';
+export { LinePath, LinePathProps } from '@/components/shapes/LinePath';
+export { MapPath, MapPathProps } from '@/components/shapes/MapPath';
+// other components
+export { Arcs, ArcsProps } from '@/components/Arcs';
+export { Area, AreaProps } from '@/components/Area';
+export { Bars, BarsProps } from '@/components/Bars';
+export { Bubbles, BubblesProps } from '@/components/Bubbles';
+export { Chart, ChartProps } from '@/components/Chart';
+export { IrregularArcs, IrregularArcsProps } from '@/components/IrregularArcs';
+export { Map, MapProps } from '@/components/Map';
+export { MapBubbles, MapBubblesProps } from '@/components/MapBubbles';
+export { Pie, PieProps } from '@/components/Pie';
+export { Points, PointsProps } from '@/components/Points';
+export {
+  ResponsiveChartContainer,
+  ResponsiveChartContainerProps,
+} from '@/components/ResponsiveChartContainer';
+export { Segments, SegmentsProps } from '@/components/Segments';
+// lib
 export { useAnimation } from '@/lib/use-animation';
 export { useChart } from '@/lib/use-chart';
 export { useMap } from '@/lib/use-map';
 export { useResponsiveChart } from '@/lib/use-responsive-chart';
 export { useToggableDatum } from '@/lib/useToggableDatum';
 export { useToggableDomainKey } from '@/lib/useToggableDomainKey';
-export { Legend, LegendProps } from '@/components/addons/legend/Legend';
-export { Tooltip, TooltipProps } from '@/components/addons/tooltip/Tooltip';
-export {
-  ResponsiveChartContainer,
-  ResponsiveChartContainerProps,
-} from '@/components/ResponsiveChartContainer';
+// recipes
 export { AreaChart, AreaChartProps } from '@/recipes/area/AreaChart';
 export {
   MultiAreaChart,

--- a/packages/ez-react/src/index.ts
+++ b/packages/ez-react/src/index.ts
@@ -1,41 +1,52 @@
-export { ColumnChart, ColumnChartProps } from '@/recipes/column/ColumnChart';
-export { BarChart, BarChartProps } from '@/recipes/bar/BarChart';
-export { PieChart, PieChartProps } from '@/recipes/pie/PieChart';
-export { LineChart, LineChartProps } from '@/recipes/line/LineChart';
-export { BubbleChart, BubbleChartProps } from '@/recipes/scatter/BubbleChart';
+export { useAnimation } from '@/lib/use-animation';
+export { useChart } from '@/lib/use-chart';
+export { useMap } from '@/lib/use-map';
+export { useResponsiveChart } from '@/lib/use-responsive-chart';
+export { useToggableDatum } from '@/lib/useToggableDatum';
+export { useToggableDomainKey } from '@/lib/useToggableDomainKey';
+export { Legend, LegendProps } from '@/components/addons/legend/Legend';
+export { Tooltip, TooltipProps } from '@/components/addons/tooltip/Tooltip';
+export {
+  ResponsiveChartContainer,
+  ResponsiveChartContainerProps,
+} from '@/components/ResponsiveChartContainer';
 export { AreaChart, AreaChartProps } from '@/recipes/area/AreaChart';
+export {
+  MultiAreaChart,
+  MultiAreaChartProps,
+} from '@/recipes/area/MultiAreaChart';
+export { BarChart, BarChartProps } from '@/recipes/bar/BarChart';
+export { ColumnChart, ColumnChartProps } from '@/recipes/column/ColumnChart';
 export {
   LineColumnChart,
   LineColumnChartProps,
 } from '@/recipes/column/LineColumnChart';
-export {
-  SemiCircleChart,
-  SemiCircleChartProps,
-} from '@/recipes/pie/SemiCircleChart';
+export { LineChart, LineChartProps } from '@/recipes/line/LineChart';
 export {
   LineErrorMarginChart,
   LineErrorMarginChartProps,
 } from '@/recipes/line/LineErrorMarginChart';
 export {
-  IrregularPieChart,
-  IrregularPieChartProps,
-} from '@/recipes/pie/IrregularPieChart';
-export {
-  ScatterChart,
-  ScatterChartProps,
-} from '@/recipes/scatter/ScatterChart';
-export { Legend, LegendProps } from '@/components/addons/legend/Legend';
-export { RadialChart, RadialChartProps } from '@/recipes/pie/RadialChart';
-export {
   MultiLineChart,
   MultiLineChartProps,
 } from '@/recipes/line/MultiLineChart';
-export { MapChart, MapChartProps } from '@/recipes/map/MapChart';
 export {
   BubbleMapChart,
   BubbleMapChartProps,
 } from '@/recipes/map/BubbleMapChart';
+export { MapChart, MapChartProps } from '@/recipes/map/MapChart';
 export {
-  ResponsiveChartContainer,
-  ResponsiveChartContainerProps,
-} from '@/components/ResponsiveChartContainer';
+  IrregularPieChart,
+  IrregularPieChartProps,
+} from '@/recipes/pie/IrregularPieChart';
+export { PieChart, PieChartProps } from '@/recipes/pie/PieChart';
+export { RadialChart, RadialChartProps } from '@/recipes/pie/RadialChart';
+export {
+  SemiCircleChart,
+  SemiCircleChartProps,
+} from '@/recipes/pie/SemiCircleChart';
+export { BubbleChart, BubbleChartProps } from '@/recipes/scatter/BubbleChart';
+export {
+  ScatterChart,
+  ScatterChartProps,
+} from '@/recipes/scatter/ScatterChart';

--- a/packages/ez-react/src/index.ts
+++ b/packages/ez-react/src/index.ts
@@ -1,7 +1,7 @@
-// addons
+// addons components
 export { Legend, LegendProps } from '@/components/addons/legend/Legend';
 export { Tooltip, TooltipProps } from '@/components/addons/tooltip/Tooltip';
-// scales
+// scales components
 export { Grid, GridProps } from '@/components/scales/grid/Grid';
 export { GridLines, GridLinesProps } from '@/components/scales/grid/GridLines';
 export { Axis, AxisProps } from '@/components/scales/Axis';
@@ -25,7 +25,7 @@ export {
   SqrtScaleProps,
   useSqrtScale,
 } from '@/components/scales/SqrtScale';
-// shapes
+// shapes components
 export { Arc, ArcProps } from '@/components/shapes/Arc';
 export { AreaPath, AreaPathProps } from '@/components/shapes/AreaPath';
 export { Bar, BarProps } from '@/components/shapes/Bar';

--- a/packages/ez-vue/src/index.ts
+++ b/packages/ez-vue/src/index.ts
@@ -1,0 +1,52 @@
+// addons components
+export * as Legend from '@/components/addons/legend/Legend';
+export * as Tooltip from '@/components/addons/tooltip/Tooltip';
+// scales components
+export * as Grid from '@/components/scales/grid/Grid';
+export * as GridLines from '@/components/scales/grid/GridLines';
+export * as Axis from '@/components/scales/Axis';
+export * as CartesianScale from '@/components/scales/CartesianScale';
+export * as ColorScale from '@/components/scales/ColorScale';
+export * as LinearScale from '@/components/scales/LinearScale';
+export * as SqrtScale from '@/components/scales/SqrtScale';
+// shapes components
+export * as Arc from '@/components/shapes/Arc';
+export * as AreaPath from '@/components/shapes/AreaPath';
+export * as Bar from '@/components/shapes/Bar';
+export * as Bubble from '@/components/shapes/Bubble';
+export * as LinePath from '@/components/shapes/LinePath';
+export * as MapPath from '@/components/shapes/MapPath';
+// other components
+export * as Arcs from '@/components/Arcs';
+export * as Area from '@/components/Area';
+export * as Bars from '@/components/Bars';
+export * as Bubbles from '@/components/Bubbles';
+export * as Chart from '@/components/Chart';
+export * as IrregularArcs from '@/components/IrregularArcs';
+export * as Map from '@/components/Map';
+export * as MapBubbles from '@/components/MapBubbles';
+export * as Pie from '@/components/Pie';
+export * as Points from '@/components/Points';
+export * as ResponsiveChartContainer from '@/components/ResponsiveChartContainer';
+export * as Segments from '@/components/Segments';
+// lib
+export * as AnimationMixin from '@/lib/AnimationMixin';
+export * as ToggleDatumMixin from '@/lib/ToggleDatumMixin';
+export * as ToggleDomainKeyMixin from '@/lib/ToggleDomainKeyMixin';
+// recipes
+export * as AreaChart from '@/recipes/area/AreaChart';
+export * as MultiAreaChart from '@/recipes/area/MultiAreaChart';
+export * as BarChart from '@/recipes/bar/BarChart';
+export * as ColumnChart from '@/recipes/column/ColumnChart';
+export * as LineColumnChart from '@/recipes/column/LineColumnChart';
+export * as LineChart from '@/recipes/line/LineChart';
+export * as LineErrorMarginChart from '@/recipes/line/LineErrorMarginChart';
+export * as MultiLineChart from '@/recipes/line/MultiLineChart';
+export * as BubbleMapChart from '@/recipes/map/BubbleMapChart';
+export * as MapChart from '@/recipes/map/MapChart';
+export * as IrregularPieChart from '@/recipes/pie/IrregularPieChart';
+export * as PieChart from '@/recipes/pie/PieChart';
+export * as RadialChart from '@/recipes/pie/RadialChart';
+export * as SemiCircleChart from '@/recipes/pie/SemiCircleChart';
+export * as BubbleChart from '@/recipes/scatter/BubbleChart';
+export * as ScatterChart from '@/recipes/scatter/ScatterChart';


### PR DESCRIPTION
# Motivation

This Fix will add the missing React exports from **lib** and from the **components** folders

Fixes # (issue)
FIX

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I have done the work for both react and vue
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (Storybook)
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
