### PR TITLE
fix: exclude undefined linear scale axis props

### DIFF
--- a/packages/ez-react/src/recipes/area/AreaChart.tsx
+++ b/packages/ez-react/src/recipes/area/AreaChart.tsx
@@ -20,6 +20,7 @@ import { Axis } from '@/components/scales/Axis';
 import { Grid } from '@/components/scales/grid/Grid';
 import { CartesianScale } from '@/components/scales/CartesianScale';
 import { Area } from '@/components/Area';
+import { getDefinedLinearScaleOptions } from '@/recipes/utils/linearScale';
 
 export interface AreaChartProps extends SVGAttributes<SVGGElement> {
   data: RawData;
@@ -96,15 +97,7 @@ export const AreaChart: FC<AreaChartProps> = ({
             domainKey: xAxis.domainKey,
             nice: xAxis.nice || 0,
             reverse: isRTL,
-            domain: xAxis.domain,
-            maxPadding: xAxis.maxPadding,
-            minPadding: xAxis.minPadding,
-            max: xAxis.max,
-            min: xAxis.min,
-            softMax: xAxis.softMax,
-            softMin: xAxis.softMin,
-            roundRange: xAxis.roundRange,
-            clamp: xAxis.clamp,
+            ...getDefinedLinearScaleOptions(xAxis),
           },
         }}
         yScaleConfig={{
@@ -113,15 +106,7 @@ export const AreaChart: FC<AreaChartProps> = ({
             direction: Direction.VERTICAL,
             domainKey: yAxis.domainKey,
             nice: yAxis.nice || 0,
-            domain: yAxis.domain,
-            maxPadding: yAxis.maxPadding,
-            minPadding: yAxis.minPadding,
-            max: yAxis.max,
-            min: yAxis.min,
-            softMax: yAxis.softMax,
-            softMin: yAxis.softMin,
-            roundRange: yAxis.roundRange,
-            clamp: yAxis.clamp,
+            ...getDefinedLinearScaleOptions(yAxis),
           },
         }}
       >

--- a/packages/ez-react/src/recipes/area/MultiAreaChart.tsx
+++ b/packages/ez-react/src/recipes/area/MultiAreaChart.tsx
@@ -7,6 +7,7 @@ import { CartesianScale } from '@/components/scales/CartesianScale';
 import { ColorScale } from '@/components/scales/ColorScale';
 import { Grid } from '@/components/scales/grid/Grid';
 import { useToggableDomainKey } from '@/lib/useToggableDomainKey';
+import { getDefinedLinearScaleOptions } from '@/recipes/utils/linearScale';
 import ScaleLinear from 'eazychart-core/src/scales/ScaleLinear';
 import {
   RawData,
@@ -108,15 +109,7 @@ export const MultiAreaChart: FC<MultiAreaChartProps> = ({
             domainKey: xAxis.domainKey,
             nice: xAxis.nice || 0,
             reverse: isRTL,
-            domain: xAxis.domain,
-            maxPadding: xAxis.maxPadding,
-            minPadding: xAxis.minPadding,
-            max: xAxis.max,
-            min: xAxis.min,
-            softMax: xAxis.softMax,
-            softMin: xAxis.softMin,
-            roundRange: xAxis.roundRange,
-            clamp: xAxis.clamp,
+            ...getDefinedLinearScaleOptions(xAxis),
           },
         }}
         yScaleConfig={{
@@ -125,14 +118,7 @@ export const MultiAreaChart: FC<MultiAreaChartProps> = ({
             direction: Direction.VERTICAL,
             domain: activeDomain,
             nice: yAxis.nice || 0,
-            maxPadding: yAxis.maxPadding,
-            minPadding: yAxis.minPadding,
-            max: yAxis.max,
-            min: yAxis.min,
-            softMax: yAxis.softMax,
-            softMin: yAxis.softMin,
-            roundRange: yAxis.roundRange,
-            clamp: yAxis.clamp,
+            ...getDefinedLinearScaleOptions(yAxis, ['domain']),
           },
         }}
       >

--- a/packages/ez-react/src/recipes/bar/BarChart.tsx
+++ b/packages/ez-react/src/recipes/bar/BarChart.tsx
@@ -21,6 +21,7 @@ import { Grid } from '@/components/scales/grid/Grid';
 import { CartesianScale } from '@/components/scales/CartesianScale';
 import { ColorScale } from '@/components/scales/ColorScale';
 import { useToggableDatum } from '@/lib/useToggableDatum';
+import { getDefinedLinearScaleOptions } from '@/recipes/utils/linearScale';
 
 export interface BarChartProps extends SVGAttributes<SVGGElement> {
   data: RawData;
@@ -98,15 +99,7 @@ export const BarChart: FC<BarChartProps> = ({
             domainKey: xAxis.domainKey,
             nice: xAxis.nice || 0,
             reverse: isRTL,
-            domain: xAxis.domain,
-            maxPadding: xAxis.maxPadding,
-            minPadding: xAxis.minPadding,
-            max: xAxis.max,
-            min: xAxis.min,
-            softMax: xAxis.softMax,
-            softMin: xAxis.softMin,
-            roundRange: xAxis.roundRange,
-            clamp: xAxis.clamp,
+            ...getDefinedLinearScaleOptions(xAxis),
           },
         }}
         yScaleConfig={{

--- a/packages/ez-react/src/recipes/column/ColumnChart.tsx
+++ b/packages/ez-react/src/recipes/column/ColumnChart.tsx
@@ -21,6 +21,7 @@ import { Grid } from '@/components/scales/grid/Grid';
 import { CartesianScale } from '@/components/scales/CartesianScale';
 import { ColorScale } from '@/components/scales/ColorScale';
 import { useToggableDatum } from '@/lib/useToggableDatum';
+import { getDefinedLinearScaleOptions } from '@/recipes/utils/linearScale';
 
 export interface ColumnChartProps extends SVGAttributes<SVGGElement> {
   data: RawData;
@@ -104,15 +105,7 @@ export const ColumnChart: FC<ColumnChartProps> = ({
             direction: Direction.VERTICAL,
             domainKey: yAxis.domainKey,
             nice: yAxis.nice || 0,
-            domain: yAxis.domain,
-            maxPadding: yAxis.maxPadding,
-            minPadding: yAxis.minPadding,
-            max: yAxis.max,
-            min: yAxis.min,
-            softMax: yAxis.softMax,
-            softMin: yAxis.softMin,
-            roundRange: yAxis.roundRange,
-            clamp: yAxis.clamp,
+            ...getDefinedLinearScaleOptions(yAxis),
           },
         }}
       >

--- a/packages/ez-react/src/recipes/column/LineColumnChart.tsx
+++ b/packages/ez-react/src/recipes/column/LineColumnChart.tsx
@@ -20,6 +20,7 @@ import { Point } from '@/components/shapes/Point';
 import { CartesianScale } from '@/components/scales/CartesianScale';
 import { ColorScale } from '@/components/scales/ColorScale';
 import { useToggableDatum } from '@/lib/useToggableDatum';
+import { getDefinedLinearScaleOptions } from '@/recipes/utils/linearScale';
 
 export interface LineColumnChartProps extends ColumnChartProps {
   yLineAxis?: AxisConfig<Position.LEFT | Position.RIGHT>;
@@ -132,15 +133,7 @@ export const LineColumnChart: FC<LineColumnChartProps> = ({
             direction: Direction.VERTICAL,
             domainKey: yLineAxis.domainKey,
             nice: yAxis.nice || 0,
-            domain: yAxis.domain,
-            maxPadding: yAxis.maxPadding,
-            minPadding: yAxis.minPadding,
-            max: yAxis.max,
-            min: yAxis.min,
-            softMax: yAxis.softMax,
-            softMin: yAxis.softMin,
-            roundRange: yAxis.roundRange,
-            clamp: yAxis.clamp,
+            ...getDefinedLinearScaleOptions(yAxis),
           },
         }}
       >

--- a/packages/ez-react/src/recipes/line/LineChart.tsx
+++ b/packages/ez-react/src/recipes/line/LineChart.tsx
@@ -20,6 +20,7 @@ import { Axis } from '@/components/scales/Axis';
 import { Grid } from '@/components/scales/grid/Grid';
 import { CartesianScale } from '@/components/scales/CartesianScale';
 import { Segments } from '@/components/Segments';
+import { getDefinedLinearScaleOptions } from '@/recipes/utils/linearScale';
 
 export interface LineChartProps extends SVGAttributes<SVGGElement> {
   data: RawData;
@@ -96,15 +97,7 @@ export const LineChart: FC<LineChartProps> = ({
             domainKey: xAxis.domainKey,
             nice: xAxis.nice || 0,
             reverse: isRTL,
-            domain: xAxis.domain,
-            maxPadding: xAxis.maxPadding,
-            minPadding: xAxis.minPadding,
-            max: xAxis.max,
-            min: xAxis.min,
-            softMax: xAxis.softMax,
-            softMin: xAxis.softMin,
-            roundRange: xAxis.roundRange,
-            clamp: xAxis.clamp,
+            ...getDefinedLinearScaleOptions(xAxis),
           },
         }}
         yScaleConfig={{
@@ -113,15 +106,7 @@ export const LineChart: FC<LineChartProps> = ({
             direction: Direction.VERTICAL,
             domainKey: yAxis.domainKey,
             nice: yAxis.nice || 0,
-            domain: yAxis.domain,
-            maxPadding: yAxis.maxPadding,
-            minPadding: yAxis.minPadding,
-            max: yAxis.max,
-            min: yAxis.min,
-            softMax: yAxis.softMax,
-            softMin: yAxis.softMin,
-            roundRange: yAxis.roundRange,
-            clamp: yAxis.clamp,
+            ...getDefinedLinearScaleOptions(yAxis),
           },
         }}
       >

--- a/packages/ez-react/src/recipes/line/LineErrorMarginChart.tsx
+++ b/packages/ez-react/src/recipes/line/LineErrorMarginChart.tsx
@@ -27,6 +27,7 @@ import { LinePath } from '@/components/shapes/LinePath';
 import { Point } from '@/components/shapes/Point';
 import { AreaPath } from '@/components/shapes/AreaPath';
 import { CartesianScale } from '@/components/scales/CartesianScale';
+import { getDefinedLinearScaleOptions } from '@/recipes/utils/linearScale';
 
 export interface LineErrorMarginChartProps extends SVGAttributes<SVGGElement> {
   line: LineConfig;
@@ -125,15 +126,7 @@ export const LineErrorMarginChart: FC<LineErrorMarginChartProps> = ({
             domainKey: xAxis.domainKey,
             nice: xAxis.nice || 0,
             reverse: isRTL,
-            domain: xAxis.domain,
-            maxPadding: xAxis.maxPadding,
-            minPadding: xAxis.minPadding,
-            max: xAxis.max,
-            min: xAxis.min,
-            softMax: xAxis.softMax,
-            softMin: xAxis.softMin,
-            roundRange: xAxis.roundRange,
-            clamp: xAxis.clamp,
+            ...getDefinedLinearScaleOptions(xAxis),
           },
         }}
         yScaleConfig={{
@@ -144,13 +137,10 @@ export const LineErrorMarginChart: FC<LineErrorMarginChartProps> = ({
             nice: yAxis.nice || 0,
             minPadding: lowsestMarginValue,
             maxPadding: highestMarginValue,
-            domain: yAxis.domain,
-            max: yAxis.max,
-            min: yAxis.min,
-            softMax: yAxis.softMax,
-            softMin: yAxis.softMin,
-            roundRange: yAxis.roundRange,
-            clamp: yAxis.clamp,
+            ...getDefinedLinearScaleOptions(yAxis, [
+              'maxPadding',
+              'minPadding',
+            ]),
           },
         }}
       >

--- a/packages/ez-react/src/recipes/line/MultiLineChart.tsx
+++ b/packages/ez-react/src/recipes/line/MultiLineChart.tsx
@@ -24,6 +24,7 @@ import { ColorScale } from '@/components/scales/ColorScale';
 import { Legend, LegendProps } from '@/components/addons/legend/Legend';
 import { Segments } from '@/components/Segments';
 import { useToggableDomainKey } from '@/lib/useToggableDomainKey';
+import { getDefinedLinearScaleOptions } from '@/recipes/utils/linearScale';
 
 export interface MultiLineChartProps extends SVGAttributes<SVGGElement> {
   data: RawData;
@@ -108,15 +109,7 @@ export const MultiLineChart: FC<MultiLineChartProps> = ({
             domainKey: xAxis.domainKey,
             nice: xAxis.nice || 0,
             reverse: isRTL,
-            domain: xAxis.domain,
-            maxPadding: xAxis.maxPadding,
-            minPadding: xAxis.minPadding,
-            max: xAxis.max,
-            min: xAxis.min,
-            softMax: xAxis.softMax,
-            softMin: xAxis.softMin,
-            roundRange: xAxis.roundRange,
-            clamp: xAxis.clamp,
+            ...getDefinedLinearScaleOptions(xAxis),
           },
         }}
         yScaleConfig={{
@@ -125,14 +118,7 @@ export const MultiLineChart: FC<MultiLineChartProps> = ({
             direction: Direction.VERTICAL,
             domain: activeDomain,
             nice: yAxis.nice || 0,
-            maxPadding: yAxis.maxPadding,
-            minPadding: yAxis.minPadding,
-            max: yAxis.max,
-            min: yAxis.min,
-            softMax: yAxis.softMax,
-            softMin: yAxis.softMin,
-            roundRange: yAxis.roundRange,
-            clamp: yAxis.clamp,
+            ...getDefinedLinearScaleOptions(yAxis, ['domain']),
           },
         }}
       >

--- a/packages/ez-react/src/recipes/scatter/BubbleChart.tsx
+++ b/packages/ez-react/src/recipes/scatter/BubbleChart.tsx
@@ -20,6 +20,7 @@ import { Grid } from '@/components/scales/grid/Grid';
 import { Bubbles } from '@/components/Bubbles';
 import { CartesianScale } from '@/components/scales/CartesianScale';
 import { LinearScale } from '@/components/scales/LinearScale';
+import { getDefinedLinearScaleOptions } from '@/recipes/utils/linearScale';
 
 export interface BubbleChartProps extends SVGAttributes<SVGGElement> {
   data: RawData;
@@ -90,15 +91,7 @@ export const BubbleChart: FC<BubbleChartProps> = ({
             domainKey: xAxis.domainKey,
             nice: xAxis.nice || 0,
             reverse: isRTL,
-            domain: xAxis.domain,
-            maxPadding: xAxis.maxPadding,
-            minPadding: xAxis.minPadding,
-            max: xAxis.max,
-            min: xAxis.min,
-            softMax: xAxis.softMax,
-            softMin: xAxis.softMin,
-            roundRange: xAxis.roundRange,
-            clamp: xAxis.clamp,
+            ...getDefinedLinearScaleOptions(xAxis),
           },
         }}
         yScaleConfig={{
@@ -107,15 +100,7 @@ export const BubbleChart: FC<BubbleChartProps> = ({
             direction: Direction.VERTICAL,
             domainKey: yAxis.domainKey,
             nice: yAxis.nice || 0,
-            domain: yAxis.domain,
-            maxPadding: yAxis.maxPadding,
-            minPadding: yAxis.minPadding,
-            max: yAxis.max,
-            min: yAxis.min,
-            softMax: yAxis.softMax,
-            softMin: yAxis.softMin,
-            roundRange: yAxis.roundRange,
-            clamp: yAxis.clamp,
+            ...getDefinedLinearScaleOptions(yAxis),
           },
         }}
       >

--- a/packages/ez-react/src/recipes/scatter/ScatterChart.tsx
+++ b/packages/ez-react/src/recipes/scatter/ScatterChart.tsx
@@ -19,6 +19,7 @@ import { Axis } from '@/components/scales/Axis';
 import { Grid } from '@/components/scales/grid/Grid';
 import { ScaleLinear } from 'eazychart-core/src';
 import { CartesianScale } from '@/components/scales/CartesianScale';
+import { getDefinedLinearScaleOptions } from '@/recipes/utils/linearScale';
 
 export interface ScatterChartProps extends SVGAttributes<SVGGElement> {
   data: RawData;
@@ -87,15 +88,7 @@ export const ScatterChart: FC<ScatterChartProps> = ({
             domainKey: xAxis.domainKey,
             nice: xAxis.nice || 0,
             reverse: isRTL,
-            domain: xAxis.domain,
-            maxPadding: xAxis.maxPadding,
-            minPadding: xAxis.minPadding,
-            max: xAxis.max,
-            min: xAxis.min,
-            softMax: xAxis.softMax,
-            softMin: xAxis.softMin,
-            roundRange: xAxis.roundRange,
-            clamp: xAxis.clamp,
+            ...getDefinedLinearScaleOptions(xAxis),
           },
         }}
         yScaleConfig={{
@@ -104,15 +97,7 @@ export const ScatterChart: FC<ScatterChartProps> = ({
             direction: Direction.VERTICAL,
             domainKey: yAxis.domainKey,
             nice: yAxis.nice || 0,
-            domain: yAxis.domain,
-            maxPadding: yAxis.maxPadding,
-            minPadding: yAxis.minPadding,
-            max: yAxis.max,
-            min: yAxis.min,
-            softMax: yAxis.softMax,
-            softMin: yAxis.softMin,
-            roundRange: yAxis.roundRange,
-            clamp: yAxis.clamp,
+            ...getDefinedLinearScaleOptions(yAxis),
           },
         }}
       >

--- a/packages/ez-react/src/recipes/utils/linearScale.ts
+++ b/packages/ez-react/src/recipes/utils/linearScale.ts
@@ -1,0 +1,45 @@
+import { ScaleLinearDefinition } from 'eazychart-core/src/types';
+
+type OptionalLinearDefinitionKey =
+  | 'domain'
+  | 'maxPadding'
+  | 'minPadding'
+  | 'max'
+  | 'min'
+  | 'softMax'
+  | 'softMin'
+  | 'roundRange'
+  | 'clamp';
+
+const optionalLinearDefinitionKeys: OptionalLinearDefinitionKey[] = [
+  'domain',
+  'maxPadding',
+  'minPadding',
+  'max',
+  'min',
+  'softMax',
+  'softMin',
+  'roundRange',
+  'clamp',
+];
+
+export const getDefinedLinearScaleOptions = (
+  definition: ScaleLinearDefinition,
+  excludeKeys: OptionalLinearDefinitionKey[] = []
+): Partial<Pick<ScaleLinearDefinition, OptionalLinearDefinitionKey>> => {
+  const options: Partial<
+    Pick<ScaleLinearDefinition, OptionalLinearDefinitionKey>
+  > = {};
+
+  optionalLinearDefinitionKeys.forEach((key) => {
+    if (excludeKeys.includes(key)) {
+      return;
+    }
+    const value = definition[key];
+    if (value !== undefined) {
+      Object.assign(options, { [key]: value });
+    }
+  });
+
+  return options;
+};


### PR DESCRIPTION
# Motivation
In This PR we exclude undefined linear scale axis props.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I have done the work for both react and vue
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (Storybook)
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
